### PR TITLE
Fix header names and value

### DIFF
--- a/src/intergration-modules/webhook-module/events/webhook.events.ts
+++ b/src/intergration-modules/webhook-module/events/webhook.events.ts
@@ -47,9 +47,9 @@ export class WebhookEvents {
                     .post(this.webhookUrl, json, {
                         headers: {
                             'Content-Type': 'application/json',
-                            'X-Remnwave-Signature': signature,
-                            'X-Remnwave-Timestamp': payload.timestamp,
-                            'User-Agent': 'Remnwave',
+                            'X-Remnawave-Signature': signature,
+                            'X-Remnawave-Timestamp': payload.timestamp,
+                            'User-Agent': 'Remnawave',
                         },
                     })
                     .pipe(
@@ -92,9 +92,9 @@ export class WebhookEvents {
                     .post(this.webhookUrl, json, {
                         headers: {
                             'Content-Type': 'application/json',
-                            'X-Remnwave-Signature': signature,
-                            'X-Remnwave-Timestamp': payload.timestamp,
-                            'User-Agent': 'Remnwave',
+                            'X-Remnawave-Signature': signature,
+                            'X-Remnawave-Timestamp': payload.timestamp,
+                            'User-Agent': 'Remnawave',
                         },
                     })
                     .pipe(


### PR DESCRIPTION
# Fix Webhook Headers Naming

## Description
This PR fixes a typo in webhook request headers, changing "Remnwave" to "Remnawave" to maintain consistency with our branding across all integration endpoints.

## Changes
- Updated `X-Remnwave-Signature` to `X-Remnawave-Signature`
- Updated `X-Remnwave-Timestamp` to `X-Remnawave-Timestamp`
- Updated `User-Agent` from "Remnwave" to "Remnawave"