### PR TITLE
feat: add node status metric for monitoring node connection state

### DIFF
--- a/libs/contract/constants/index.ts
+++ b/libs/contract/constants/index.ts
@@ -5,3 +5,4 @@ export * from './nodes';
 export * from './roles';
 export * from './templates';
 export * from './users';
+export * from './metrics';

--- a/libs/contract/constants/metrics/index.ts
+++ b/libs/contract/constants/metrics/index.ts
@@ -1,0 +1,1 @@
+export * from './metric-names.constant';

--- a/libs/contract/constants/metrics/metric-names.constant.ts
+++ b/libs/contract/constants/metrics/metric-names.constant.ts
@@ -1,0 +1,7 @@
+export const METRIC_NAMES = {
+    NODE_ONLINE_USERS: 'node_online_users',
+    NODE_STATUS: 'node_status',
+} as const;
+
+export type TMetricNames = typeof METRIC_NAMES;
+export type TMetricNamesKeys = (typeof METRIC_NAMES)[keyof typeof METRIC_NAMES];

--- a/src/modules/jobs/jobs.module.ts
+++ b/src/modules/jobs/jobs.module.ts
@@ -15,6 +15,11 @@ import { JOBS_SERVICES } from './tasks';
             help: 'Number of online users on a node',
             labelNames: ['node_uuid', 'node_name'],
         }),
+        makeGaugeProvider({
+            name: 'node_status',
+            help: 'Node connection status (1 - connected, 0 - disconnected)',
+            labelNames: ['node_uuid', 'node_name'],
+        }),
     ],
 })
 export class JobsModule {}

--- a/src/modules/jobs/jobs.module.ts
+++ b/src/modules/jobs/jobs.module.ts
@@ -5,21 +5,10 @@ import { Module } from '@nestjs/common';
 import { PrometheusReporterModule } from '@intergration-modules/prometheus-reporter/prometheus-reporter.module';
 
 import { JOBS_SERVICES } from './tasks';
+import { METRIC_PROVIDERS } from './metrics-providers';
 
 @Module({
     imports: [CqrsModule, PrometheusReporterModule],
-    providers: [
-        ...JOBS_SERVICES,
-        makeGaugeProvider({
-            name: 'node_online_users',
-            help: 'Number of online users on a node',
-            labelNames: ['node_uuid', 'node_name'],
-        }),
-        makeGaugeProvider({
-            name: 'node_status',
-            help: 'Node connection status (1 - connected, 0 - disconnected)',
-            labelNames: ['node_uuid', 'node_name'],
-        }),
-    ],
+    providers: [...JOBS_SERVICES, ...METRIC_PROVIDERS],
 })
 export class JobsModule {}

--- a/src/modules/jobs/metrics-providers.ts
+++ b/src/modules/jobs/metrics-providers.ts
@@ -1,0 +1,15 @@
+import { METRIC_NAMES } from '@libs/contracts/constants';
+import { makeGaugeProvider } from '@willsoto/nestjs-prometheus';
+
+export const METRIC_PROVIDERS = [
+    makeGaugeProvider({
+        name: METRIC_NAMES.NODE_ONLINE_USERS,
+        help: 'Number of online users on a node',
+        labelNames: ['node_uuid', 'node_name'],
+    }),
+    makeGaugeProvider({
+        name: METRIC_NAMES.NODE_STATUS,
+        help: 'Node connection status (1 - connected, 0 - disconnected)',
+        labelNames: ['node_uuid', 'node_name'],
+    }),
+];

--- a/src/modules/jobs/tasks/node-health-check/node-health-check.service.ts
+++ b/src/modules/jobs/tasks/node-health-check/node-health-check.service.ts
@@ -144,9 +144,9 @@ export class NodeHealthCheckService {
             },
         });
 
-        this.nodeStatus.set({ node_uuid: node.uuid, node_name: node.name }, 0);
-
         this.eventBus.publish(new StartNodeEvent(newNodeEntity.response || node));
+
+        this.nodeStatus.set({ node_uuid: node.uuid, node_name: node.name }, 0);
 
         if (node.isConnected) {
             node.lastStatusMessage = message || null;

--- a/src/modules/jobs/tasks/node-health-check/node-health-check.service.ts
+++ b/src/modules/jobs/tasks/node-health-check/node-health-check.service.ts
@@ -4,6 +4,8 @@ import { Cron, SchedulerRegistry } from '@nestjs/schedule';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { Injectable, Logger } from '@nestjs/common';
 import pMap from '@cjs-exporter/p-map';
+import { InjectMetric } from '@willsoto/nestjs-prometheus';
+import { Gauge } from 'prom-client';
 
 import { NodeEvent } from '@intergration-modules/telegram-bot/events/nodes/interfaces';
 import { formatExecutionTime, getTime } from '@common/utils/get-elapsed-time';
@@ -27,6 +29,7 @@ export class NodeHealthCheckService {
     private CONCURRENCY: number;
     private isNodesRestarted: boolean;
     constructor(
+        @InjectMetric('node_status') public nodeStatus: Gauge<string>,
         private readonly schedulerRegistry: SchedulerRegistry,
         private readonly queryBus: QueryBus,
         private readonly commandBus: CommandBus,
@@ -114,6 +117,8 @@ export class NodeHealthCheckService {
             },
         });
 
+        this.nodeStatus.set({ node_uuid: node.uuid, node_name: node.name }, 1);
+
         if (!node.isConnected) {
             this.eventEmitter.emit(
                 EVENTS.NODE.CONNECTION_RESTORED,
@@ -138,6 +143,8 @@ export class NodeHealthCheckService {
                 usersOnline: 0,
             },
         });
+
+        this.nodeStatus.set({ node_uuid: node.uuid, node_name: node.name }, 0);
 
         this.eventBus.publish(new StartNodeEvent(newNodeEntity.response || node));
 

--- a/src/modules/jobs/tasks/record-user-usage/record-user-usage.service.ts
+++ b/src/modules/jobs/tasks/record-user-usage/record-user-usage.service.ts
@@ -19,6 +19,7 @@ import { AxiosService } from '@common/axios';
 import { NodesEntity } from '@modules/nodes';
 
 import { JOBS_INTERVALS } from '../../intervals';
+import { METRIC_NAMES } from '@libs/contracts/constants';
 
 @Injectable()
 export class RecordUserUsageService {
@@ -28,7 +29,7 @@ export class RecordUserUsageService {
     private cronName: string;
     private CONCURRENCY: number;
     constructor(
-        @InjectMetric('node_online_users') public nodeOnlineUsers: Gauge<string>,
+        @InjectMetric(METRIC_NAMES.NODE_ONLINE_USERS) public nodeOnlineUsers: Gauge<string>,
         private readonly schedulerRegistry: SchedulerRegistry,
         private readonly queryBus: QueryBus,
         private readonly commandBus: CommandBus,


### PR DESCRIPTION
### Description
This PR adds a new Prometheus gauge metric `node_status` to track the connection status of nodes in real-time. The metric provides binary status information where:
- 1 indicates a connected node
- 0 indicates a disconnected node

### Changes
- Added new gauge metric provider in `jobs.module.ts` for tracking node status
- Integrated status reporting in `node-health-check.service.ts`
- Status updates occur during both connection restoration and failure scenarios

### Technical Details
- Metric name: `node_status`
- Labels: `node_uuid`, `node_name`
- Value range: 0 or 1
- Updated in real-time as part of the health check service

### Use Cases
- Real-time monitoring of node connection states
- Alert creation based on connection status changes
- Integration with monitoring dashboards
- Historical connection stability analysis