### PR TITLE
chore: bump version to 1.4.6 and update environment configuration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@remnawave/backend",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@remnawave/backend",
-      "version": "1.4.5",
+      "version": "1.4.6",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@bull-board/api": "^6.7.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remnawave/backend",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "description": "Remnawave Panel Backend",
   "private": false,
   "type": "commonjs",

--- a/src/bin/gen-doc/gen-doc.ts
+++ b/src/bin/gen-doc/gen-doc.ts
@@ -14,6 +14,7 @@ process.env.IS_DOCS_ENABLED = 'true';
 process.env.NODE_ENV = 'development';
 process.env.REDIS_HOST = 'localhost';
 process.env.REDIS_PORT = '6379';
+process.env.INSTANCE_TYPE = 'api';
 
 import { utilities as nestWinstonModuleUtilities, WinstonModule } from 'nest-winston';
 import { patchNestJsSwagger, ZodValidationPipe } from 'nestjs-zod';


### PR DESCRIPTION
- Updated version in package.json and package-lock.json to 1.4.6.
- Added INSTANCE_TYPE environment variable in gen-doc.ts for API configuration.