### PR TITLE
feat: Make SHORT_UUID_LENGTH configurable

### DIFF
--- a/src/common/config/app-config/config.schema.ts
+++ b/src/common/config/app-config/config.schema.ts
@@ -46,6 +46,11 @@ export const configSchema = z
             .transform((db) => parseInt(db, 10))
             .refine((db) => db >= 0 && db <= 15, 'Redis DB index must be between 0 and 15')
             .default('1'),
+        SHORT_UUID_LENGTH: z
+            .string()
+            .default('16')
+            .transform((val) => parseInt(val, 10))
+            .refine((val) => val >= 16 && val <= 64, 'SHORT_UUID_LENGTH must be between 16 and 64'),
     })
     .superRefine((data, ctx) => {
         if (data.WEBHOOK_ENABLED === 'true') {

--- a/src/modules/users/users.service.ts
+++ b/src/modules/users/users.service.ts
@@ -3,6 +3,7 @@ import { Prisma } from '@prisma/client';
 import { customAlphabet } from 'nanoid';
 import utc from 'dayjs/plugin/utc';
 import dayjs from 'dayjs';
+import { ConfigService } from '@nestjs/config';
 
 import { CommandBus, EventBus, QueryBus } from '@nestjs/cqrs';
 import { Transactional } from '@nestjs-cls/transactional';
@@ -59,6 +60,7 @@ export class UsersService {
         private readonly eventBus: EventBus,
         private readonly eventEmitter: EventEmitter2,
         private readonly queryBus: QueryBus,
+        private readonly configService: ConfigService,
     ) {}
 
     public async createUser(
@@ -737,7 +739,8 @@ export class UsersService {
 
     private createNanoId(): string {
         const alphabet = '0123456789ABCDEFGHJKLMNPQRSTUVWXYZ_abcdefghjkmnopqrstuvwxyz-';
-        const nanoid = customAlphabet(alphabet, 16);
+        const length = this.configService.get('SHORT_UUID_LENGTH', 16);
+        const nanoid = customAlphabet(alphabet, length);
 
         return nanoid();
     }


### PR DESCRIPTION
This PR adds a SHORT_UUID_LENGTH variable that allows the SHORT_UUID length to be configured.

For example, SHORT_UUUID_LENGTH=64

This makes bruteforcing more difficult.