### PR TITLE
Add clarifying comment for SUB_PUBLIC_DOMAIN in Docker config

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -28,12 +28,13 @@ TELEGRAM_ADMIN_ID=change_me
 NODES_NOTIFY_CHAT_ID=change_me
 
 ### FRONT_END ###
-FRONT_END_DOMAIN=*
+FRONT_END_DOMAIN=panel.example.com
 
 ### SUBSCRIPTION PUBLIC DOMAIN ###
-### RAW DOMAIN, WITHOUT HTTP/HTTPS, DO NOT PLACE / to end of domain ###
+### RAW DOMAIN, WITHOUT HTTP/HTTPS, DO NOT ADD / AT THE END ###
 ### Used in "profile-web-page-url" response header ###
-SUB_PUBLIC_DOMAIN=example.com
+### If CUSTOM_SUB_PREFIX is set in remnawave-subscription-page, append the same path to SUB_PUBLIC_DOMAIN. Example: SUB_PUBLIC_DOMAIN=sub-page.example.com/sub
+SUB_PUBLIC_DOMAIN=sub-page.example.com
 
 ### SWAGGER ###
 SWAGGER_PATH=/docs


### PR DESCRIPTION
Added a detailed comment to SUB_PUBLIC_DOMAIN environment variable to clarify its usage with CUSTOM_SUB_PREFIX in remnawave-subscription-page. This ensures developers understand how to configure the domain path correctly, avoiding misconfiguration.