### PR TITLE
Add clarifying comment for SUB_PUBLIC_DOMAIN in Docker config

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -33,13 +33,16 @@ TELEGRAM_ADMIN_THREAD_ID=
 NODES_NOTIFY_THREAD_ID=
 
 ### FRONT_END ###
-FRONT_END_DOMAIN=panel.example.com
+# Used by CORS, you can leave it as * or place your domain there
+FRONT_END_DOMAIN=*
 
 ### SUBSCRIPTION PUBLIC DOMAIN ###
-### RAW DOMAIN, WITHOUT HTTP/HTTPS, DO NOT ADD / AT THE END ###
-### Used in "profile-web-page-url" response header ###
-### If CUSTOM_SUB_PREFIX is set in remnawave-subscription-page, append the same path to SUB_PUBLIC_DOMAIN. Example: SUB_PUBLIC_DOMAIN=sub-page.example.com/sub
-SUB_PUBLIC_DOMAIN=sub-page.example.com
+### DOMAIN, WITHOUT HTTP/HTTPS, DO NOT ADD / AT THE END ###
+### Used in "profile-web-page-url" response header and in UI/API ###
+### Review documentation: https://remna.st/installation/env#subscription-public-domain
+SUB_PUBLIC_DOMAIN=panel.domain.com/api/sub
+
+### If CUSTOM_SUB_PREFIX is set in @remnawave/subscription-page, append the same path to SUB_PUBLIC_DOMAIN. Example: SUB_PUBLIC_DOMAIN=sub-page.example.com/sub
 
 ### SWAGGER ###
 SWAGGER_PATH=/docs

--- a/.env.sample
+++ b/.env.sample
@@ -33,12 +33,13 @@ TELEGRAM_ADMIN_THREAD_ID=
 NODES_NOTIFY_THREAD_ID=
 
 ### FRONT_END ###
-FRONT_END_DOMAIN=*
+FRONT_END_DOMAIN=panel.example.com
 
 ### SUBSCRIPTION PUBLIC DOMAIN ###
-### RAW DOMAIN, WITHOUT HTTP/HTTPS, DO NOT PLACE / to end of domain ###
+### RAW DOMAIN, WITHOUT HTTP/HTTPS, DO NOT ADD / AT THE END ###
 ### Used in "profile-web-page-url" response header ###
-SUB_PUBLIC_DOMAIN=example.com
+### If CUSTOM_SUB_PREFIX is set in remnawave-subscription-page, append the same path to SUB_PUBLIC_DOMAIN. Example: SUB_PUBLIC_DOMAIN=sub-page.example.com/sub
+SUB_PUBLIC_DOMAIN=sub-page.example.com
 
 ### SWAGGER ###
 SWAGGER_PATH=/docs


### PR DESCRIPTION
Added a detailed comment to SUB_PUBLIC_DOMAIN environment variable to clarify its usage with CUSTOM_SUB_PREFIX in remnawave-subscription-page. This ensures developers understand how to configure the domain path correctly, avoiding misconfiguration.