### PR TITLE
fix: delete unused fields in XrayJsonDefaultConfig

### DIFF
--- a/prisma/seed/config.seed.ts
+++ b/prisma/seed/config.seed.ts
@@ -515,7 +515,6 @@ export const XrayJsonDefaultConfig = {
             settings: {
                 udp: true,
                 auth: 'noauth',
-                allowTransparent: false,
             },
             sniffing: {
                 enabled: true,
@@ -529,8 +528,6 @@ export const XrayJsonDefaultConfig = {
             listen: '127.0.0.1',
             protocol: 'http',
             settings: {
-                udp: true,
-                auth: 'noauth',
                 allowTransparent: false,
             },
             sniffing: {


### PR DESCRIPTION
В документации этих полей нет, они не используются.

[Socks xtls doc](https://xtls.github.io/ru/config/inbounds/socks.html#inboundconfigurationobject)
[Http xtls doc](https://xtls.github.io/ru/config/inbounds/http.html)