### PR TITLE
chore: release v1.6.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@remnawave/backend",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@remnawave/backend",
-      "version": "1.6.3",
+      "version": "1.6.4",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@bull-board/api": "^6.9.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remnawave/backend",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "description": "Remnawave Panel Backend",
   "private": false,
   "type": "commonjs",

--- a/src/modules/subscription-template/render-templates.service.ts
+++ b/src/modules/subscription-template/render-templates.service.ts
@@ -196,7 +196,6 @@ export class RenderTemplatesService {
             /^Happ\//,
             /^ktor-client/,
             /^V2Box/,
-            /^v2raytun[\w\-]*\//,
             /^io\.github\.saeeddev94\.xray\//,
         ];
 


### PR DESCRIPTION
- Updated package version from 1.6.3 to 1.6.4 in package.json and package-lock.json.
- Removed v2raytun user agent regex from the render-templates.service.ts file.