### PR TITLE
feat: add proxies shuffling for Mihomo and Clash proxy-groups

### DIFF
--- a/src/modules/subscription-template/generators/clash.generator.service.ts
+++ b/src/modules/subscription-template/generators/clash.generator.service.ts
@@ -1,4 +1,5 @@
 import yaml from 'yaml';
+import _ from 'lodash';
 
 import { Injectable, Logger } from '@nestjs/common';
 
@@ -124,6 +125,16 @@ export class ClashGeneratorService {
 
                     if (randomProxy) {
                         group.proxies.push(randomProxy);
+                    }
+
+                    continue;
+                }
+
+                if (remnawaveCustom && remnawaveCustom['shuffle-proxies-order'] === true) {
+                    const shuffledProxies = _.shuffle(proxyRemarks);
+
+                    for (const proxyRemark of shuffledProxies) {
+                        group.proxies.push(proxyRemark);
                     }
 
                     continue;

--- a/src/modules/subscription-template/generators/mihomo.generator.service.ts
+++ b/src/modules/subscription-template/generators/mihomo.generator.service.ts
@@ -1,4 +1,5 @@
 import yaml from 'yaml';
+import _ from 'lodash';
 
 import { Injectable, Logger } from '@nestjs/common';
 
@@ -126,6 +127,16 @@ export class MihomoGeneratorService {
 
                     if (randomProxy) {
                         group.proxies.push(randomProxy);
+                    }
+
+                    continue;
+                }
+
+                if (remnawaveCustom && remnawaveCustom['shuffle-proxies-order'] === true) {
+                    const shuffledProxies = _.shuffle(proxyRemarks);
+
+                    for (const proxyRemark of shuffledProxies) {
+                        group.proxies.push(proxyRemark);
                     }
 
                     continue;


### PR DESCRIPTION
When 'shuffle-proxies-order' is set to true, the order of proxies is randomized before being added to a proxy-group.