### PR TITLE
Add GRPC as a valid network type

### DIFF
--- a/src/common/helpers/xray-config/xray-config.validator.ts
+++ b/src/common/helpers/xray-config/xray-config.validator.ts
@@ -80,7 +80,7 @@ export class XRayConfig {
         for (const inbound of this.config.inbounds) {
             const network = inbound.streamSettings?.network;
 
-            if (network && !['httpupgrade', 'raw', 'tcp', 'ws', 'xhttp'].includes(network)) {
+            if (network && !['httpupgrade', 'raw', 'tcp', 'ws', 'grpc', 'xhttp'].includes(network)) {
                 throw new Error(
                     `Invalid network type "${network}" in inbound "${inbound.tag}". Allowed values are: httpupgrade, raw, xhttp, ws, tcp`,
                 );


### PR DESCRIPTION
This PR fixes the https://github.com/remnawave/panel/issues/123

TLDR: XRay supports GRPC as a network type, but the backend validation doesn't. This PR fixes the issue