### PR TITLE
fix(docker): Restore curl for healthcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,15 +53,12 @@ WORKDIR /opt/app
 
 ARG BRANCH=main
 
-# Install curl
-RUN apk add --no-cache curl
-
 # Install jemalloc
 # RUN apk add --no-cache jemalloc
 # ENV LD_PRELOAD=/usr/lib/libjemalloc.so.2
 # libunwind
 # Install mimalloc
-RUN apk add --no-cache mimalloc 
+RUN apk add --no-cache mimalloc curl
 ENV LD_PRELOAD=/usr/lib/libmimalloc.so
 
 ENV REMNAWAVE_BRANCH=${BRANCH}

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,8 +53,11 @@ WORKDIR /opt/app
 
 ARG BRANCH=main
 
+# Install curl
+RUN apk add --no-cache curl
+
 # Install jemalloc
-# RUN apk add --no-cache jemalloc curl
+# RUN apk add --no-cache jemalloc
 # ENV LD_PRELOAD=/usr/lib/libjemalloc.so.2
 # libunwind
 # Install mimalloc


### PR DESCRIPTION
### Summary

This PR restores the `curl` package to the Docker image, which is necessary for the `healthcheck` to function correctly.

### The Problem

In commit 76ea25da3b31a7440e3cce7dc0924d2ab279c307, the `curl` package was accidentally commented out along with `jemalloc`.

As a result, everyone who uses `docker-compose.yaml` from the documentation will have `unhealthy`.