### PR TITLE
fix: очистка stale метрик нод при каждом цикле экспорта

### DIFF
--- a/src/scheduler/tasks/export-metrics/export-metrics.task.ts
+++ b/src/scheduler/tasks/export-metrics/export-metrics.task.ts
@@ -166,6 +166,10 @@ export class ExportMetricsTask {
 
             const nodes = nodesResponse.response;
 
+            // Clear stale metrics for deleted nodes
+            this.nodeOnlineUsers.reset();
+            this.nodeStatus.reset();
+
             nodes.forEach((node) => {
                 this.nodeOnlineUsers.set(
                     {


### PR DESCRIPTION
## Описание проблемы

Когда нода удаляется из базы данных, её метрики (`remnawave_node_status`, `remnawave_node_online_users`) остаются в памяти prom-client навсегда, потому что `Gauge.set()` только добавляет/обновляет значения, но никогда не удаляет старые комбинации лейблов.

Это приводит к тому, что удалённые ноды продолжают отображаться в Prometheus со значением `0`.

## Решение

Вызов `reset()` для `nodeOnlineUsers` и `nodeStatus` gauges перед итерацией по текущим нодам. Это гарантирует, что метрики будут только для существующих в БД нод.

## Изменения

- Добавлен `this.nodeOnlineUsers.reset()` перед циклом
- Добавлен `this.nodeStatus.reset()` перед циклом

## Тестирование

- [ ] Создать ноду
- [ ] Проверить что метрика появилась в `/metrics`
- [ ] Удалить ноду
- [ ] Дождаться следующего цикла экспорта метрик
- [ ] Проверить что метрика удалённой ноды исчезла