### PR TITLE
feat(auth): add Keycloak OAuth2 provider

### DIFF
--- a/libs/contract/commands/auth/get-status.command.ts
+++ b/libs/contract/commands/auth/get-status.command.ts
@@ -28,7 +28,6 @@ export namespace GetStatusCommand {
                     }),
                     oauth2: z.object({
                         providers: z.record(z.nativeEnum(OAUTH2_PROVIDERS), z.boolean()),
-                        keycloakSeamlessAuth: z.boolean().optional(),
                     }),
                     password: z.object({
                         enabled: z.boolean(),

--- a/libs/contract/models/remnawave-settings/oauth2-settings.schema.ts
+++ b/libs/contract/models/remnawave-settings/oauth2-settings.schema.ts
@@ -35,26 +35,57 @@ export const Oauth2SettingsSchema = z.object({
         clientSecret: z.nullable(z.string()),
         allowedEmails: z.array(z.string()),
     }),
-    keycloak: z.object({
-        enabled: z.boolean(),
-        domain: z
-            .string()
-            .refine(
-                (val) => {
-                    const fqdnRegex =
-                        /(?=^.{4,253}$)(^((?!-)[a-zA-Z0-9-]{0,62}[a-zA-Z0-9]\.)+[a-zA-Z]{2,63}$)/;
-                    return fqdnRegex.test(val);
-                },
-                {
-                    message: 'Must be a valid fully qualified domain name (FQDN), e.g. "keycloak.example.com"',
-                },
-            )
-            .nullable(),
-        realm: z.nullable(z.string()),
-        clientId: z.nullable(z.string()),
-        clientSecret: z.nullable(z.string()),
-        seamlessAuth: z.boolean().default(false),
-    }),
+    keycloak: z
+        .object({
+            enabled: z.boolean(),
+            realm: z.nullable(z.string()),
+            clientId: z.nullable(z.string()),
+            clientSecret: z.nullable(z.string()),
+            frontendDomain: z.nullable(
+                z.string().refine(
+                    (val) => {
+                        const fqdnRegex =
+                            /(?=^.{4,253}$)(^((?!-)[a-zA-Z0-9-]{0,62}[a-zA-Z0-9]\.)+[a-zA-Z]{2,63}$)/;
+                        if (fqdnRegex.test(val)) {
+                            return true;
+                        }
+
+                        return false;
+                    },
+                    {
+                        message:
+                            'Must be a valid fully qualified domain name (FQDN), e.g. "docs.rw"',
+                    },
+                ),
+            ),
+            keycloakDomain: z.nullable(
+                z.string().refine(
+                    (val) => {
+                        const fqdnRegex =
+                            /(?=^.{4,253}$)(^((?!-)[a-zA-Z0-9-]{0,62}[a-zA-Z0-9]\.)+[a-zA-Z]{2,63}$)/;
+                        if (fqdnRegex.test(val)) {
+                            return true;
+                        }
+
+                        return false;
+                    },
+                    {
+                        message:
+                            'Must be a valid fully qualified domain name (FQDN), e.g. "docs.rw"',
+                    },
+                ),
+            ),
+            allowedEmails: z.array(z.string()),
+        })
+        .default({
+            enabled: false,
+            realm: null,
+            frontendDomain: null,
+            keycloakDomain: null,
+            clientId: null,
+            clientSecret: null,
+            allowedEmails: [],
+        }),
 });
 
 export type TOauth2Settings = z.infer<typeof Oauth2SettingsSchema>;

--- a/libs/contract/package.json
+++ b/libs/contract/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remnawave/backend-contract",
-  "version": "2.5.9",
+  "version": "2.5.12",
   "public": true,
   "license": "AGPL-3.0-only",
   "description": "A contract library for Remnawave Backend. It can be used in backend and frontend.",
@@ -29,8 +29,5 @@
   "keywords": [],
   "dependencies": {
     "zod": "3.25.76"
-  },
-  "devDependencies": {
-    "typescript": "^5.9.3"
   }
 }

--- a/prisma/seed/config.seed.ts
+++ b/prisma/seed/config.seed.ts
@@ -20,6 +20,7 @@ import {
 import { RemnawaveSettingsEntity } from '@modules/remnawave-settings/entities/remnawave-settings.entity';
 import {
     CustomRemarksSchema,
+    Oauth2SettingsSchema,
     PasskeySettingsSchema,
     TBrandingSettings,
     TCustomRemarks,
@@ -806,11 +807,12 @@ async function seedRemnawaveSettings() {
         },
         keycloak: {
             enabled: false,
-            domain: null,
             realm: null,
             clientId: null,
             clientSecret: null,
-            seamlessAuth: false,
+            keycloakDomain: null,
+            frontendDomain: null,
+            allowedEmails: [],
         },
     };
 
@@ -845,6 +847,18 @@ async function seedRemnawaveSettings() {
                     data: { [key]: value },
                 });
             } else {
+                if (key === 'oauth2Settings') {
+                    const oauthSchemaParseResult = Oauth2SettingsSchema.safeParse(
+                        existingConfig.oauth2Settings,
+                    );
+                    if (oauthSchemaParseResult.success) {
+                        await prisma.remnawaveSettings.update({
+                            where: { id: existingConfig.id },
+                            data: { [key]: oauthSchemaParseResult.data },
+                        });
+                    }
+                }
+
                 if (key === 'passkeySettings') {
                     if (!PasskeySettingsSchema.safeParse(existingConfig.passkeySettings).success) {
                         consola.warn(`${key} is not valid! Falling back to default...`);

--- a/src/modules/auth/model/get-status.response.model.ts
+++ b/src/modules/auth/model/get-status.response.model.ts
@@ -10,7 +10,6 @@ interface IAuthentication {
     };
     oauth2: {
         providers: Record<TOAuth2ProvidersKeys, boolean>;
-        keycloakSeamlessAuth?: boolean;
     };
     password: {
         enabled: boolean;

--- a/src/modules/remnawave-settings/remnawave-settings.service.ts
+++ b/src/modules/remnawave-settings/remnawave-settings.service.ts
@@ -77,7 +77,10 @@ export class RemnawaveSettingsService {
                 settings.oauth2Settings.yandex,
             ];
 
-            const genericOAuth2Providers = [settings.oauth2Settings.pocketid];
+            const genericOAuth2Providers = [
+                settings.oauth2Settings.pocketid,
+                settings.oauth2Settings.keycloak,
+            ];
 
             // Test 1: At least one authentication method must be enabled
             if (
@@ -85,6 +88,7 @@ export class RemnawaveSettingsService {
                 !settings.oauth2Settings.github.enabled &&
                 !settings.oauth2Settings.pocketid.enabled &&
                 !settings.oauth2Settings.yandex.enabled &&
+                !settings.oauth2Settings.keycloak.enabled &&
                 !settings.tgAuthSettings.enabled &&
                 !settings.passwordSettings.enabled
             ) {
@@ -129,11 +133,14 @@ export class RemnawaveSettingsService {
 
             // Test 4.1: Check up required fields for Keycloak authentication
             if (settings.oauth2Settings.keycloak.enabled) {
-                const kc = settings.oauth2Settings.keycloak;
-                if (!kc.domain || !kc.realm || !kc.clientId || !kc.clientSecret) {
+                if (
+                    !settings.oauth2Settings.keycloak.frontendDomain ||
+                    !settings.oauth2Settings.keycloak.keycloakDomain ||
+                    !settings.oauth2Settings.keycloak.realm
+                ) {
                     return {
                         valid: false,
-                        error: '[Keycloak] Domain, realm, client ID and client secret must be set in order to use Keycloak authentication.',
+                        error: '[Keycloak] Frontend domain, Keycloak domain and Realm must be set in order to use Keycloak authentication.',
                     };
                 }
             }


### PR DESCRIPTION
## Summary
- Add Keycloak to OAuth2 providers constants
- Implement Keycloak callback with role-based access (admin role)
- Add Keycloak settings schema (domain, realm, clientId, clientSecret, seamlessAuth)
- Add validation for Keycloak settings
- Expose keycloakSeamlessAuth in auth status response

## Related PRs
- Frontend: remnawave/frontend (pending)
- Docs: remnawave/panel (pending)