### PR TITLE
Add PocketID OIDC groups check

### DIFF
--- a/libs/contract/models/remnawave-settings/oauth2-settings.schema.ts
+++ b/libs/contract/models/remnawave-settings/oauth2-settings.schema.ts
@@ -28,6 +28,7 @@ export const Oauth2SettingsSchema = z.object({
             ),
         ),
         allowedEmails: z.array(z.string()),
+        allowedGroups: z.array(z.string()),
     }),
     yandex: z.object({
         enabled: z.boolean(),

--- a/prisma/seed/config.seed.ts
+++ b/prisma/seed/config.seed.ts
@@ -797,6 +797,7 @@ async function seedRemnawaveSettings() {
             clientSecret: null,
             plainDomain: null,
             allowedEmails: [],
+            allowedGroups: [],
         },
         yandex: {
             enabled: false,

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -447,8 +447,8 @@ export class AuthService {
                     );
                     const scopes = ['email', 'profile'];
                     if (
-                        pocketIdSettings.allowedGroups &&
-                        pocketIdSettings.allowedGroups.length > 0
+                        remnawaveSettings.oauth2Settings.pocketid.allowedGroups &&
+                        remnawaveSettings.oauth2Settings.pocketid.allowedGroups.length > 0
                     ) {
                         scopes.push('groups');
                     }
@@ -779,14 +779,17 @@ export class AuthService {
                 return { isAllowed: true, email };
             }
 
-            if (pocketIdSettings.allowedGroups && pocketIdSettings.allowedGroups.length > 0) {
+            if (
+                remnawaveSettings.oauth2Settings.pocketid.allowedGroups &&
+                remnawaveSettings.oauth2Settings.pocketid.allowedGroups.length > 0
+            ) {
                 const userGroups =
                     'groups' in claims && Array.isArray(claims.groups)
                         ? (claims.groups as string[])
                         : [];
 
                 const hasAllowedGroup = userGroups.some((group) =>
-                    pocketIdSettings.allowedGroups.includes(group),
+                    remnawaveSettings.oauth2Settings.pocketid.allowedGroups.includes(group),
                 );
 
                 if (hasAllowedGroup) {


### PR DESCRIPTION
## Description
This PR add support for **OIDC Group verification** during the authentication process for the PocketID provider.

Currently, access is restricted to users whose emails are explicitly listed in the panel or those who have a custom claim (remnawaveClaim). This change allows for a more standard OIDC flow by restricting access based on the `groups` claim provided in the ID token.

### Frontend
Need to add new field + logic (what should be filled or field with mail/group) + I18N to support new fields.
#### Example configuration
<img width="710" height="557" alt="Image" src="https://github.com/user-attachments/assets/98874046-2d8a-435a-b7b9-2f2833d47c51" />