### PR TITLE
perf: add indexes to improve query performance in `users`, `user_traffic`, `hosts`, and `internal_squad_inbounds` tables

### DIFF
--- a/prisma/migrations/20260323175509_add_performance_indexes/migration.sql
+++ b/prisma/migrations/20260323175509_add_performance_indexes/migration.sql
@@ -1,0 +1,26 @@
+-- CreateIndex
+CREATE INDEX "users_status_expire_at_idx" ON "users"("status", "expire_at");
+
+-- CreateIndex
+CREATE INDEX "users_traffic_limit_strategy_status_idx" ON "users"("traffic_limit_strategy", "status");
+
+-- CreateIndex
+CREATE INDEX "users_expire_at_idx" ON "users"("expire_at");
+
+-- CreateIndex
+CREATE INDEX "users_external_squad_uuid_idx" ON "users"("external_squad_uuid");
+
+-- CreateIndex
+CREATE INDEX "users_telegram_id_idx" ON "users"("telegram_id");
+
+-- CreateIndex
+CREATE INDEX "users_created_at_idx" ON "users"("created_at");
+
+-- CreateIndex
+CREATE INDEX "user_traffic_online_at_idx" ON "user_traffic"("online_at");
+
+-- CreateIndex
+CREATE INDEX "hosts_config_profile_inbound_uuid_idx" ON "hosts"("config_profile_inbound_uuid");
+
+-- CreateIndex
+CREATE INDEX "internal_squad_inbounds_inbound_uuid_idx" ON "internal_squad_inbounds"("inbound_uuid");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -81,6 +81,12 @@ model Users {
 
   externalSquad ExternalSquads? @relation(fields: [externalSquadUuid], references: [uuid], onDelete: SetNull)
 
+  @@index([status, expireAt])
+  @@index([trafficLimitStrategy, status])
+  @@index([expireAt])
+  @@index([externalSquadUuid])
+  @@index([telegramId])
+  @@index([createdAt])
   @@map("users")
 }
 
@@ -98,6 +104,7 @@ model UserTraffic {
   user              Users  @relation(fields: [tId], references: [tId], onDelete: Cascade)
   lastConnectedNode Nodes? @relation(fields: [lastConnectedNodeUuid], references: [uuid], onDelete: SetNull)
 
+  @@index([onlineAt])
   @@map("user_traffic")
 }
 
@@ -300,6 +307,7 @@ model Hosts {
   nodes                  HostsToNodes[]
   excludedInternalSquads InternalSquadHostExclusions[]
 
+  @@index([configProfileInboundUuid])
   @@map("hosts")
 }
 
@@ -407,6 +415,7 @@ model InternalSquadInbounds {
   inbound       ConfigProfileInbounds @relation(fields: [inboundUuid], references: [uuid], onDelete: Cascade)
 
   @@id([internalSquadUuid, inboundUuid])
+  @@index([inboundUuid])
   @@map("internal_squad_inbounds")
 }
 


### PR DESCRIPTION
added indexes for more perfomance
                                                                                                                                                                                                               
  - **users**: `[status, expire_at]`, `[traffic_limit_strategy, status]`, `[expire_at]`, `[external_squad_uuid]`, `[telegram_id]`, `[created_at]` — cron tasks/users dashboard/get user by param in API                                                                                                                                        
  - **user_traffic**: `[online_at]` — online calculation
  - **hosts**: `[config_profile_inbound_uuid]` — hot path for subscription generation
  - **internal_squad_inbounds**: `[inbound_uuid]` — hot path for subscription generation