### PR TITLE
feat: add hy2:// link generation for XRAY_BASE64 subscription

### DIFF
--- a/src/modules/subscription-template/generators/xray.generator.service.ts
+++ b/src/modules/subscription-template/generators/xray.generator.service.ts
@@ -38,13 +38,7 @@ export class XrayGeneratorService {
             if (!link) continue;
 
             if (isHapp && host.clientOverrides.serverDescription) {
-                const fragmentIndex = link.indexOf('#');
-                const [base, fragment] =
-                    fragmentIndex >= 0
-                        ? [link.slice(0, fragmentIndex), link.slice(fragmentIndex)]
-                        : [link, ''];
-                const separator = base.includes('?') ? '&' : '?';
-                links.push(`${base}${separator}serverDescription=${host.clientOverrides.serverDescription}${fragment}`);
+                links.push(`${link}?serverDescription=${host.clientOverrides.serverDescription}`);
             } else {
                 links.push(link);
             }

--- a/src/modules/subscription-template/generators/xray.generator.service.ts
+++ b/src/modules/subscription-template/generators/xray.generator.service.ts
@@ -133,6 +133,8 @@ export class XrayGeneratorService {
     private buildHysteriaLink(
         host: Extract<ResolvedProxyConfig, { protocol: 'hysteria' }>,
     ): string | null {
+        if (host.transport !== 'hysteria') return null;
+
         const params: Record<string, unknown> = {};
 
         if (host.security === 'tls') {
@@ -145,7 +147,6 @@ export class XrayGeneratorService {
             }
         }
 
-        if (host.transport !== 'hysteria') return null;
         const auth = encodeURIComponent(host.transportOptions.auth);
         const remark = encodeURIComponent(host.finalRemark);
         const query = this.buildQueryString(params);

--- a/src/modules/subscription-template/generators/xray.generator.service.ts
+++ b/src/modules/subscription-template/generators/xray.generator.service.ts
@@ -38,7 +38,13 @@ export class XrayGeneratorService {
             if (!link) continue;
 
             if (isHapp && host.clientOverrides.serverDescription) {
-                links.push(`${link}?serverDescription=${host.clientOverrides.serverDescription}`);
+                const fragmentIndex = link.indexOf('#');
+                const [base, fragment] =
+                    fragmentIndex >= 0
+                        ? [link.slice(0, fragmentIndex), link.slice(fragmentIndex)]
+                        : [link, ''];
+                const separator = base.includes('?') ? '&' : '?';
+                links.push(`${base}${separator}serverDescription=${host.clientOverrides.serverDescription}${fragment}`);
             } else {
                 links.push(link);
             }
@@ -55,6 +61,8 @@ export class XrayGeneratorService {
                 return this.buildTrojanLink(host);
             case 'shadowsocks':
                 return this.buildShadowsocksLink(host);
+            case 'hysteria':
+                return this.buildHysteriaLink(host);
             default:
                 return null;
         }
@@ -123,6 +131,34 @@ export class XrayGeneratorService {
         const remark = encodeURIComponent(host.finalRemark);
 
         return `ss://${credentials}@${host.address}:${host.port}#${remark}`;
+    }
+
+    // ── Hysteria2 ─────────────────────────────────────
+    // hy2://auth@host:port?params#remark
+
+    private buildHysteriaLink(
+        host: Extract<ResolvedProxyConfig, { protocol: 'hysteria' }>,
+    ): string | null {
+        const params: Record<string, unknown> = {};
+
+        if (host.security === 'tls') {
+            const opts = host.securityOptions;
+            if (opts.serverName) {
+                params.sni = opts.serverName;
+            }
+            if (opts.allowInsecure) {
+                params.insecure = 1;
+            }
+        }
+
+        if (host.transport !== 'hysteria') return null;
+        const auth = encodeURIComponent(host.transportOptions.auth);
+        const remark = encodeURIComponent(host.finalRemark);
+        const query = this.buildQueryString(params);
+
+        return query
+            ? `hy2://${auth}@${host.address}:${host.port}?${query}#${remark}`
+            : `hy2://${auth}@${host.address}:${host.port}#${remark}`;
     }
 
     // ── Transport Params ─────────────────────────────


### PR DESCRIPTION
## Summary

- Add Hysteria2 (`hy2://`) share link generation to the XRAY_BASE64 subscription format, which previously only supported vless/trojan/ss protocols and silently dropped Hysteria2 hosts

## Details

### Problem

The `generateLink()` switch in `xray.generator.service.ts` had no `case 'hysteria'` — any Hysteria2 host returned `null` and was excluded from XRAY_BASE64 output. This affected all clients that consume base64 subscriptions (v2rayN, Hiddify, Streisand, Happ).

### Solution

New `buildHysteriaLink()` method produces standard `hy2://` URIs:

```
hy2://auth@host:port?sni=example.com&insecure=1#remark
```

- Auth password sourced from `transportOptions.auth` (per-user UUID synced to nodes)
- Only emits `sni` and `insecure` TLS params per the hy2:// URI spec (not VLESS/Trojan params like `fp`, `alpn`, `security` which don't apply to Hysteria2)
- Runtime guard on `host.transport !== 'hysteria'` for correct TypeScript narrowing
- Omits query string entirely when no TLS params are needed

### Important note for node configuration

Hysteria2 inbound TLS config requires `"alpn": ["h3"]` in `tlsSettings` for clients to connect. Without this, the QUIC handshake fails with `tls: no application protocol`.

## Test plan

- [x] TypeScript compilation passes (local + Docker strict mode)
- [x] Multi-platform Docker build succeeds (linux/amd64 + linux/arm64)
- [x] Subscription output contains correctly formatted `hy2://` links
- [x] Hysteria2 CLI client connects using per-user UUID auth
- [x] Happ client imports subscription and connects successfully
- [x] Existing vless/trojan/ss links remain unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)