### PR TITLE
feat: поле tag хоста из строки в массив tags

### DIFF
--- a/libs/contract/commands/hosts/create.command.ts
+++ b/libs/contract/commands/hosts/create.command.ts
@@ -63,19 +63,23 @@ export namespace CreateHostCommand {
                 })
                 .nullable(),
         ),
-        tag: z
+        tags: z
             .optional(
                 z
-                    .string()
-                    .regex(
-                        /^[A-Z0-9_:]+$/,
-                        'Tag can only contain uppercase letters, numbers, underscores and colons',
+                    .array(
+                        z
+                            .string()
+                            .regex(
+                                /^[A-Z0-9_:]+$/,
+                                'Tag can only contain uppercase letters, numbers, underscores and colons',
+                            )
+                            .max(32, 'Tag must be less than 32 characters'),
                     )
-                    .max(32, 'Tag must be less than 32 characters')
-                    .nullable(),
+                    .max(10, 'Maximum 10 tags allowed')
+                    .default([]),
             )
             .describe(
-                'Optional. Host tag for categorization. Max 32 characters, uppercase letters, numbers, underscores and colons are allowed.',
+                'Optional. Host tags for categorization. Max 10 tags, each max 32 characters, uppercase letters, numbers, underscores and colons are allowed.',
             ),
         isHidden: z.optional(z.boolean().default(false)),
         overrideSniFromAddress: z.optional(z.boolean().default(false)),

--- a/libs/contract/commands/hosts/update.command.ts
+++ b/libs/contract/commands/hosts/update.command.ts
@@ -67,19 +67,22 @@ export namespace UpdateHostCommand {
                 })
                 .nullable(),
         ),
-        tag: z
+        tags: z
             .optional(
                 z
-                    .string()
-                    .regex(
-                        /^[A-Z0-9_:]+$/,
-                        'Tag can only contain uppercase letters, numbers, underscores and colons',
+                    .array(
+                        z
+                            .string()
+                            .regex(
+                                /^[A-Z0-9_:]+$/,
+                                'Tag can only contain uppercase letters, numbers, underscores and colons',
+                            )
+                            .max(32, 'Tag must be less than 32 characters'),
                     )
-                    .max(32, 'Tag must be less than 32 characters')
-                    .nullable(),
+                    .max(10, 'Maximum 10 tags allowed'),
             )
             .describe(
-                'Optional. Host tag for categorization. Max 32 characters, uppercase letters, numbers, underscores and colons are allowed.',
+                'Optional. Host tags for categorization. Max 10 tags, each max 32 characters, uppercase letters, numbers, underscores and colons are allowed.',
             ),
         isHidden: z.optional(z.boolean()),
         overrideSniFromAddress: z.optional(z.boolean()),

--- a/libs/contract/models/hosts.schema.ts
+++ b/libs/contract/models/hosts.schema.ts
@@ -27,7 +27,7 @@ export const HostsSchema = z.object({
     }),
 
     serverDescription: z.string().max(30).nullable(),
-    tag: z.string().nullable(),
+    tags: z.array(z.string()).default([]),
     isHidden: z.boolean().default(false),
     overrideSniFromAddress: z.boolean().default(false),
     keepSniBlank: z.boolean().default(false),

--- a/libs/contract/models/resolved-proxy-config.schema.ts
+++ b/libs/contract/models/resolved-proxy-config.schema.ts
@@ -203,7 +203,7 @@ export const SecurityVariantSchema = z.discriminatedUnion('security', [
 
 export const ProxyEntryMetadataSchema = z.object({
     uuid: z.string().uuid(),
-    tag: z.string().nullable(),
+    tags: z.array(z.string()).default([]),
     excludeFromSubscriptionTypes: z.array(z.nativeEnum(SUBSCRIPTION_TEMPLATE_TYPE)),
     inboundTag: z.string(),
     configProfileUuid: z.string().uuid().nullable(),

--- a/prisma/migrations/20260408_migrate_host_tag_to_tags/migration.sql
+++ b/prisma/migrations/20260408_migrate_host_tag_to_tags/migration.sql
@@ -1,0 +1,10 @@
+-- AlterTable: migrate host tag (single string) to tags (array of strings)
+
+-- Step 1: Add new tags column with default empty array
+ALTER TABLE "hosts" ADD COLUMN "tags" TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[];
+
+-- Step 2: Migrate existing tag data to tags array
+UPDATE "hosts" SET "tags" = ARRAY["tag"] WHERE "tag" IS NOT NULL;
+
+-- Step 3: Drop old tag column
+ALTER TABLE "hosts" DROP COLUMN "tag";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -282,7 +282,7 @@ model Hosts {
   keepSniBlank                 Boolean  @default(false) @map("keep_sni_blank")
   excludeFromSubscriptionTypes String[] @default([]) @map("exclude_from_subscription_types")
 
-  tag      String? @map("tag")
+  tags     String[] @default([]) @map("tags")
   isHidden Boolean @default(false) @map("is_hidden")
 
   overrideSniFromAddress Boolean @default(false) @map("override_sni_from_address")

--- a/src/modules/hosts/entities/hosts.entity.ts
+++ b/src/modules/hosts/entities/hosts.entity.ts
@@ -26,7 +26,7 @@ export class HostsEntity implements Hosts {
     serverDescription: null | string;
     allowInsecure: boolean;
 
-    tag: null | string;
+    tags: string[];
     isHidden: boolean;
 
     overrideSniFromAddress: boolean;

--- a/src/modules/hosts/hosts.converter.ts
+++ b/src/modules/hosts/hosts.converter.ts
@@ -34,7 +34,7 @@ const entityToModel = (entity: HostsEntity): Hosts => {
         shuffleHost: entity.shuffleHost,
         mihomoX25519: entity.mihomoX25519,
 
-        tag: entity.tag,
+        tags: entity.tags,
         isHidden: entity.isHidden,
 
         overrideSniFromAddress: entity.overrideSniFromAddress,

--- a/src/modules/hosts/models/host.response.model.ts
+++ b/src/modules/hosts/models/host.response.model.ts
@@ -26,7 +26,7 @@ export class HostResponseModel {
     public shuffleHost: boolean;
     public mihomoX25519: boolean;
 
-    public tag: null | string;
+    public tags: string[];
     public isHidden: boolean;
 
     public overrideSniFromAddress: boolean;
@@ -69,7 +69,7 @@ export class HostResponseModel {
         this.shuffleHost = data.shuffleHost;
         this.mihomoX25519 = data.mihomoX25519;
 
-        this.tag = data.tag;
+        this.tags = data.tags;
         this.isHidden = data.isHidden;
 
         this.overrideSniFromAddress = data.overrideSniFromAddress;

--- a/src/modules/hosts/repositories/hosts.repository.ts
+++ b/src/modules/hosts/repositories/hosts.repository.ts
@@ -1,4 +1,5 @@
 import { Prisma } from '@prisma/client';
+import { sql } from 'kysely';
 
 import { IReorderHost } from 'src/modules/hosts/interfaces/reorder-host.interface';
 
@@ -93,6 +94,7 @@ export class HostsRepository implements ICrud<HostsEntity> {
             | 'excludedInternalSquads'
             | 'excludeFromSubscriptionTypes'
             | 'finalMask'
+            | 'tags'
         >,
     ): Promise<HostsEntity[]> {
         const list = await this.prisma.tx.hosts.findMany({
@@ -245,14 +247,15 @@ export class HostsRepository implements ICrud<HostsEntity> {
     }
 
     public async getAllHostTags(): Promise<string[]> {
-        const result = await this.prisma.tx.hosts.findMany({
-            select: {
-                tag: true,
-            },
-            distinct: ['tag'],
-        });
+        const result = await this.qb.kysely
+            .selectFrom('hosts')
+            .select(sql<string>`unnest(tags)`.as('tag'))
+            .distinct()
+            .where('tags', 'is not', null)
+            .orderBy('tag')
+            .execute();
 
-        return result.map((host) => host.tag).filter((tag) => tag !== null);
+        return result.map((value) => value.tag);
     }
 
     public async addNodesToHost(hostUuid: string, nodes: string[]): Promise<boolean> {

--- a/src/modules/subscription-template/generators/xray-json.generator.service.ts
+++ b/src/modules/subscription-template/generators/xray-json.generator.service.ts
@@ -351,7 +351,9 @@ export class XrayJsonGeneratorService {
         }
 
         if (useHostTagAsTag) {
-            return hosts.map((h) => this.buildOutbound(h, h.metadata.tag || h.finalRemark));
+            return hosts.map((h) =>
+                this.buildOutbound(h, h.metadata.tags[0] || h.finalRemark),
+            );
         }
 
         const proxyTag = tagPrefix ?? 'proxy';
@@ -404,13 +406,17 @@ export class XrayJsonGeneratorService {
             case 'sameTagAsRecipient':
                 return candidates.filter(
                     (h) =>
-                        h.metadata.tag && host.metadata.tag && h.metadata.tag === host.metadata.tag,
+                        h.metadata.tags.length > 0 &&
+                        host.metadata.tags.length > 0 &&
+                        h.metadata.tags.some((t) => host.metadata.tags.includes(t)),
                 );
 
             case 'tagRegex': {
                 const regex = this.parseRegex(selector.pattern);
                 if (!regex) return [];
-                return candidates.filter((h) => h.metadata.tag && regex.test(h.metadata.tag));
+                return candidates.filter(
+                    (h) => h.metadata.tags.length > 0 && h.metadata.tags.some((t) => regex.test(t)),
+                );
             }
         }
     }

--- a/src/modules/subscription-template/resolve-proxy/interfaces/resolved-proxy-config.interface.ts
+++ b/src/modules/subscription-template/resolve-proxy/interfaces/resolved-proxy-config.interface.ts
@@ -186,7 +186,7 @@ export type SecurityVariant = TlsSecurity | RealitySecurity | NoneSecurity;
 
 export interface IProxyEntryMetadata {
     uuid: string;
-    tag: string | null;
+    tags: string[];
     excludeFromSubscriptionTypes: TSubscriptionTemplateType[];
     inboundTag: string;
     configProfileUuid: string | null;

--- a/src/modules/subscription-template/resolve-proxy/resolve-proxy-config.service.ts
+++ b/src/modules/subscription-template/resolve-proxy/resolve-proxy-config.service.ts
@@ -564,7 +564,7 @@ export class ResolveProxyConfigService {
             },
             metadata: {
                 uuid: inputHost.uuid,
-                tag: inputHost.tag,
+                tags: inputHost.tags,
                 excludeFromSubscriptionTypes: inputHost.excludeFromSubscriptionTypes,
                 inboundTag: inputHost.inboundTag,
                 configProfileUuid: inputHost.configProfileUuid,
@@ -676,7 +676,7 @@ export class ResolveProxyConfigService {
                     },
                     metadata: {
                         uuid: '00000000-0000-0000-0000-000000000000',
-                        tag: null,
+                        tags: [],
                         excludeFromSubscriptionTypes: [],
                         inboundTag: '',
                         configProfileUuid: null,


### PR DESCRIPTION
## Описание

Миграция поля хоста `tag` из одиночной строки (`tag: string | null`) в массив (`tags: string[]`) — по аналогии с тем, как теги уже реализованы для нод.

### Мотивация

Сейчас хост поддерживает только один тег, в то время как ноды уже поддерживают несколько. Это ограничивает возможности маркировки — например, нельзя пометить хост сразу для нескольких сценариев использования (тип канала, регион, назначение и т.д.).

### Что изменено

**База данных:**
- Prisma-схема: `tag String?` → `tags String[] @default([])`
- SQL-миграция: добавляет колонку `tags`, переносит данные из `tag`, удаляет старую колонку

**Контракт (libs/contract):**
- `HostsSchema`: `tag: z.string().nullable()` → `tags: z.array(z.string()).default([])`
- `CreateHostCommand` / `UpdateHostCommand`: валидация массива с regex на каждый элемент, максимум 10 тегов
- `ProxyEntryMetadataSchema`: `tag` → `tags`

**Бэкенд:**
- `HostsEntity`, `HostResponseModel`, `HostsConverter`: обновление типа поля
- `HostsRepository.getAllHostTags()`: переписан на `unnest(tags)` (как в нодах)
- `HostsRepository.findByCriteria()`: исключён `tags` из Prisma where-фильтра
- `resolve-proxy-config.service.ts`: маппинг metadata `tag` → `tags`
- `xray-json.generator.service.ts`:
  - `useHostTagAsTag`: берёт первый тег как outbound tag
  - `sameTagAsRecipient`: проверяет пересечение массивов
  - `tagRegex`: матчит если хотя бы один тег подходит под regex

### Ломающие изменения

Изменён API-контракт во всех ручках хостов (`POST /api/hosts`, `PATCH /api/hosts`, `GET /api/hosts`): поле `tag: string | null` заменено на `tags: string[]`. Фронтенд обновлён в remnawave/frontend#340.