### PR TITLE
feat: implemented incy routing like happ

### DIFF
--- a/src/modules/subscription/subscription.service.ts
+++ b/src/modules/subscription/subscription.service.ts
@@ -164,6 +164,7 @@ export class SubscriptionService {
                         headers: await this.getUserProfileHeadersInfo(
                             user.response,
                             /^Happ\//.test(userAgent),
+                            /^INCY\//.test(userAgent),
                             subscriptionSettings,
                         ),
                         body: '',
@@ -273,6 +274,7 @@ export class SubscriptionService {
                 headers: await this.getUserProfileHeadersInfo(
                     user.response,
                     /^Happ\//.test(userAgent),
+                    /^INCY\//.test(userAgent),
                     subscriptionSettings,
                     isHwidLimitActive,
                 ),
@@ -326,6 +328,7 @@ export class SubscriptionService {
             const headers = await this.getUserProfileHeadersInfo(
                 user,
                 /^Happ\//.test(userAgent),
+                /^INCY\//.test(userAgent),
                 patchedSettingEntity,
             );
 
@@ -586,6 +589,7 @@ export class SubscriptionService {
     private async getUserProfileHeadersInfo(
         user: UserEntity,
         isHapp: boolean,
+        isIncy: boolean,
         settings: SubscriptionSettingsEntity,
         hwidLimit: boolean = false,
     ): Promise<ISubscriptionHeaders> {
@@ -619,6 +623,10 @@ export class SubscriptionService {
 
         if (isHapp && settings.happRouting) {
             headers.routing = settings.happRouting;
+        }
+
+        if (isIncy && settings.happRouting) {
+            headers.routing = settings.happRouting.replaceAll('happ', 'incy');
         }
 
         if (settings.isProfileWebpageUrlEnabled) {


### PR DESCRIPTION
## Summary

Добавление поддержки маршрутизации для клиента **[INCY](https://incy.cc)** по аналогии с уже существующей логикой для **Happ**.

## Motivation / Context

Клиент INCY должен получать корректный `routing`-заголовок подписки, совместимый с его схемой маршрутизации. До этого специальная маршрутизация применялась только для `Happ/*` user-agent, поэтому INCY-клиент не получал адаптированное значение.

## What changed

- Добавлено определение Incy-клиента по user-agent `INCY/*`.
- В `SubscriptionService.getUserProfileHeadersInfo(...)` добавлен флаг `isIncy`.
- Для INCY используется существующая настройка `happRouting`, но значение адаптируется заменой `happ` на `incy`.
- Логика применена во всех местах, где формируются headers профиля пользователя, включая сценарии с HWID-лимитами и subpage config.

Изменённый файл:

- `src/modules/subscription/subscription.service.ts`

## User-facing behavior

Если запрос подписки приходит от клиента с user-agent вида `INCY/*` и в настройках включён `happRouting`, ответ будет содержать `routing`-заголовок для Incy:

```ts
headers.routing = settings.happRouting.replaceAll('happ', 'incy');
```

Для Happ поведение остаётся прежним. Для остальных клиентов поведение не меняется.

## Risks / Notes for reviewers

- INCY routing завязан на существующую настройку `happRouting`, поэтому изменение предполагает, что формат маршрутизации INCY полностью совместим с Happ после текстовой замены `happ` на `incy`.
- Если в будущем у INCY появятся отличия от Happ routing, лучше выделить отдельную настройку вместо переиспользования `happRouting`.
