### PR TITLE
remove yaml alias limit

### DIFF
--- a/src/modules/subscription-template/subscription-template.service.ts
+++ b/src/modules/subscription-template/subscription-template.service.ts
@@ -328,7 +328,7 @@ export class SubscriptionTemplateService {
             case 'MIHOMO':
             case 'STASH':
             case 'CLASH':
-                templateContent = yaml.parse(template.templateYaml!);
+                templateContent = yaml.parse(template.templateYaml!, { maxAliasCount: -1 });
                 break;
             case 'SINGBOX':
             case 'XRAY_JSON':


### PR DESCRIPTION
default value for maxAliasCount was 100 https://eemeli.org/yaml/#tojs-options
if the limit is exceeded, the method returns {}
(my last PR was from the wrong branch)