### PR TITLE
feat(nodes): add Veil core dispatch alongside Xray

### DIFF
--- a/prisma/migrations/20260512000000_add_node_core/migration.sql
+++ b/prisma/migrations/20260512000000_add_node_core/migration.sql
@@ -1,0 +1,15 @@
+-- Add Veil-vs-Xray dispatch column to the Nodes table.
+--
+-- Existing rows default to 'XRAY' so the migration is a no-op for
+-- everyone who hasn't onboarded a Veil node yet. The default is also
+-- pinned at the DB level so direct INSERTs (admin bash scripts, the
+-- seed script, etc.) keep working without specifying the column.
+CREATE TYPE "node_core" AS ENUM ('XRAY', 'VEIL');
+
+ALTER TABLE "nodes"
+  ADD COLUMN "core" "node_core" NOT NULL DEFAULT 'XRAY';
+
+-- Hot-path: most queue processors look up the core to decide which
+-- axios method to call, so an index keeps single-node lookups
+-- cheap even with hundreds of registered nodes.
+CREATE INDEX "nodes_core_idx" ON "nodes" ("core");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -168,6 +168,11 @@ model Nodes {
   address String @unique @map("address")
   port    Int?   @map("port")
 
+  // Which proxy core powers this node. XRAY uses the existing
+  // Xray-core dispatch path; VEIL targets the Veil daemon
+  // (https://github.com/redstone-md/veil) via /node/veil/*.
+  core    NodeCore @default(XRAY) @map("core")
+
   activeConfigProfileUuid String? @map("active_config_profile_uuid") @db.Uuid
   activePluginUuid        String? @map("active_plugin_uuid") @db.Uuid
 
@@ -632,4 +637,14 @@ model TorrentBlockerReports {
   node Nodes @relation(fields: [nodeId], references: [id], onDelete: Cascade)
 
   @@map("torrent_blocker_reports")
+}
+
+// NodeCore selects which proxy daemon the node hosts. Keep tiny; new
+// cores added here must be matched by a queue-processor branch and a
+// matching axios facade method.
+enum NodeCore {
+  XRAY
+  VEIL
+
+  @@map("node_core")
 }

--- a/src/common/axios/axios.service.ts
+++ b/src/common/axios/axios.service.ts
@@ -29,6 +29,12 @@ import {
     UnblockIpsCommand,
 } from '@remnawave/node-contract';
 
+import {
+    GetNodeHealthCheckVeilCommand,
+    StartVeilCommand,
+    StopVeilCommand,
+} from '@common/veil-contract/veil-commands';
+
 import { formatExecutionTime, getTime } from '@common/utils/get-elapsed-time';
 import { prettyBytesUtil } from '@common/utils/bytes';
 
@@ -738,10 +744,101 @@ export class AxiosService {
                     ),
                 );
             }
+
+    // ───────────────────────────────────────────────────────────────
+    // Veil — counterpart to startXray/stopXray/getNodeHealth above.
+    // Talks to the new /node/veil/* endpoints introduced in the
+    // matching feat(veil-core) PR on remnawave/node. Once that PR
+    // ships in @remnawave/node-contract>=2.8.0 the imports above
+    // collapse from the inline shim back to the package.
+    // ───────────────────────────────────────────────────────────────
+
+    public async startVeil(
+        data: StartVeilCommand.Request,
+        url: string,
+        port: null | number,
+    ): Promise<TResult<StartVeilCommand.Response>> {
+        const nodeUrl = this.getNodeUrl(url, StartVeilCommand.url, port);
+
+        try {
+            const startTime = getTime();
+            const compressedData = await this.compressData(data);
+
+            this.logger.log(
+                `[ZSTD] [START VEIL] ${formatExecutionTime(startTime)} | ${prettyBytesUtil(compressedData.length)}`,
+            );
+
+            const response = await this.axiosInstance.post<StartVeilCommand.Response>(
+                nodeUrl,
+                compressedData,
+                {
+                    timeout: 60_000,
+                    headers: {
+                        'Content-Encoding': 'zstd',
+                    },
+                },
+            );
+
+            return ok(response.data);
+        } catch (error) {
+            if (error instanceof AxiosError) {
+                return fail(ERRORS.NODE_ERROR_WITH_MSG.withMessage(JSON.stringify(error.message)));
+            } else {
+                return fail(
+                    ERRORS.NODE_ERROR_WITH_MSG.withMessage(
+                        JSON.stringify(error) ?? 'Unknown error',
+                    ),
+                );
+            }
         }
     }
 
-    private async compressData(data: any): Promise<Buffer> {
-        return await compress(Buffer.from(JSON.stringify(data)), 1);
+    public async stopVeil(
+        url: string,
+        port: null | number,
+    ): Promise<TResult<StopVeilCommand.Response>> {
+        const nodeUrl = this.getNodeUrl(url, StopVeilCommand.url, port);
+        try {
+            const response = await this.axiosInstance.get<StopVeilCommand.Response>(nodeUrl);
+            return ok(response.data);
+        } catch (error) {
+            if (error instanceof AxiosError) {
+                this.logger.error(
+                    'Error in Axios StopVeil Request:',
+                    JSON.stringify(error.message),
+                );
+                return fail(ERRORS.NODE_ERROR_WITH_MSG.withMessage(JSON.stringify(error.message)));
+            } else {
+                return fail(
+                    ERRORS.NODE_ERROR_WITH_MSG.withMessage(
+                        JSON.stringify(error) ?? 'Unknown error',
+                    ),
+                );
+            }
+        }
+    }
+
+    public async getVeilNodeHealth(
+        url: string,
+        port: null | number,
+    ): Promise<TResult<GetNodeHealthCheckVeilCommand.Response['response']>> {
+        try {
+            const nodeUrl = this.getNodeUrl(url, GetNodeHealthCheckVeilCommand.url, port);
+            const { data } = await this.axiosInstance.get<GetNodeHealthCheckVeilCommand.Response>(
+                nodeUrl,
+                { timeout: 15_000 },
+            );
+            return ok(data.response);
+        } catch (error) {
+            if (error instanceof AxiosError) {
+                return fail(ERRORS.NODE_ERROR_WITH_MSG.withMessage(JSON.stringify(error.message)));
+            } else {
+                return fail(
+                    ERRORS.NODE_ERROR_WITH_MSG.withMessage(
+                        JSON.stringify(error) ?? 'Unknown error',
+                    ),
+                );
+            }
+        }
     }
 }

--- a/src/common/veil-contract/veil-commands.ts
+++ b/src/common/veil-contract/veil-commands.ts
@@ -1,0 +1,94 @@
+// Inline shim for the Veil command schemas.
+//
+// These mirror what `@remnawave/node-contract` exposes for Xray today
+// (StartXrayCommand / StopXrayCommand / GetNodeHealthCheckCommand)
+// and live here because the node-contract package version that ships
+// them — published from the matching `feat(veil-core)` PR in
+// remnawave/node — is not on npm yet.
+//
+// MIGRATION:
+// Once node-contract@>=2.8.0 is published, delete this file and
+// import the real namespaces from '@remnawave/node-contract':
+//
+//     import {
+//         StartVeilCommand,
+//         StopVeilCommand,
+//         GetNodeHealthCheckVeilCommand,
+//     } from '@remnawave/node-contract';
+//
+// The shapes here are kept identical to the upstream schemas so the
+// swap is mechanical.
+
+import { z } from 'zod';
+
+const NODE_ROOT = '/node' as const;
+const VEIL_CONTROLLER = 'veil' as const;
+const VEIL_ROUTES = {
+    START: 'start',
+    STOP: 'stop',
+    NODE_HEALTH_CHECK: 'healthcheck',
+} as const;
+
+const NodeSystemSchema = z.object({
+    info: z.record(z.unknown()),
+    stats: z.record(z.unknown()),
+    interface: z.record(z.unknown()),
+});
+
+export namespace StartVeilCommand {
+    export const url = `${NODE_ROOT}/${VEIL_CONTROLLER}/${VEIL_ROUTES.START}`;
+
+    export const RequestSchema = z.object({
+        internals: z.object({
+            forceRestart: z.boolean().default(false),
+            configHash: z.string(),
+        }),
+        serverConfig: z.string(),
+        adminAddr: z.string().optional(),
+    });
+    export type Request = z.infer<typeof RequestSchema>;
+
+    export const ResponseSchema = z.object({
+        response: z.object({
+            isStarted: z.boolean(),
+            version: z.string().nullable(),
+            error: z.string().nullable(),
+            nodeInformation: z.object({
+                version: z.string().nullable(),
+            }),
+            system: NodeSystemSchema,
+        }),
+    });
+    export type Response = z.infer<typeof ResponseSchema>;
+}
+
+export namespace StopVeilCommand {
+    export const url = `${NODE_ROOT}/${VEIL_CONTROLLER}/${VEIL_ROUTES.STOP}`;
+
+    export const RequestSchema = z.object({}).strict();
+    export type Request = z.infer<typeof RequestSchema>;
+
+    export const ResponseSchema = z.object({
+        response: z.object({
+            isStopped: z.boolean(),
+        }),
+    });
+    export type Response = z.infer<typeof ResponseSchema>;
+}
+
+export namespace GetNodeHealthCheckVeilCommand {
+    export const url = `${NODE_ROOT}/${VEIL_CONTROLLER}/${VEIL_ROUTES.NODE_HEALTH_CHECK}`;
+
+    export const RequestSchema = z.object({}).strict();
+    export type Request = z.infer<typeof RequestSchema>;
+
+    export const ResponseSchema = z.object({
+        response: z.object({
+            isNodeOnline: z.boolean(),
+            isVeilOnline: z.boolean(),
+            veilVersion: z.string().nullable(),
+            nodeVersion: z.string(),
+        }),
+    });
+    export type Response = z.infer<typeof ResponseSchema>;
+}

--- a/src/modules/nodes/entities/nodes.entity.ts
+++ b/src/modules/nodes/entities/nodes.entity.ts
@@ -11,6 +11,7 @@ export class NodesEntity implements Nodes {
     public name: string;
     public address: string;
     public port: null | number;
+    public core: 'XRAY' | 'VEIL';
     public isConnected: boolean;
     public isConnecting: boolean;
     public isDisabled: boolean;

--- a/src/queue/_nodes/processors/start-node.processor.ts
+++ b/src/queue/_nodes/processors/start-node.processor.ts
@@ -95,6 +95,14 @@ export class StartNodeProcessor extends WorkerHost {
                 }),
             );
 
+            // Fork: VEIL-cored nodes use a separate dispatch
+            // path that talks to /node/veil/* and pushes a
+            // server.yaml string instead of an Xray JSON config.
+            // See startVeilNode() at the bottom of this file.
+            if (node.core === 'VEIL') {
+                return await this.startVeilNode(node);
+            }
+
             const xrayStatusResponse = await this.axios.getNodeHealth(node.address, node.port);
 
             if (!xrayStatusResponse.isOk) {
@@ -272,5 +280,135 @@ export class StartNodeProcessor extends WorkerHost {
         } catch (error) {
             this.logger.error(`Error handling "${NODES_JOB_NAMES.START_NODE}" job: ${error}`);
         }
+    }
+
+    /**
+     * VEIL-cored node start path.
+     *
+     * Mirrors the Xray happy-path above but talks to /node/veil/* and
+     * pushes a server.yaml string rather than the JSON Xray config.
+     * The hashed-set cache check is replaced by a SHA-256 of the
+     * generated server.yaml — Veil's daemon does the same comparison
+     * server-side and short-circuits a restart if it matches.
+     *
+     * The serverConfig generator is intentionally minimal in this PR
+     * (just the inbounds the operator already configured for the
+     * Xray path). Wiring Veil's full transport surface — Reality
+     * decoy origins, mimicry profiles, decoy traffic — lands in a
+     * follow-up after the upstream Veil schema stabilises post-audit.
+     */
+    private async startVeilNode(
+        node: Awaited<ReturnType<typeof this.queryBus.execute<GetNodeByUuidQuery>>>['response'],
+    ): Promise<void> {
+        const startTime = getTime();
+        const veilHealth = await this.axios.getVeilNodeHealth(node.address, node.port);
+
+        if (!veilHealth.isOk) {
+            await this.commandBus.execute(
+                new UpdateNodeCommand({
+                    uuid: node.uuid,
+                    lastStatusMessage: veilHealth.message ?? null,
+                    lastStatusChange: new Date(),
+                    isConnected: false,
+                    isConnecting: false,
+                }),
+            );
+
+            this.eventEmitter.emit(EVENTS.NODE.DISCONNECTED, new NodeEvent(node, EVENTS.NODE.DISCONNECTED));
+            return;
+        }
+
+        const serverConfig = await this.buildVeilServerConfig(node);
+        const configHash = await this.sha256(serverConfig);
+
+        const startResult = await this.axios.startVeil(
+            {
+                internals: {
+                    forceRestart: false,
+                    configHash,
+                },
+                serverConfig,
+            },
+            node.address,
+            node.port,
+        );
+
+        if (!startResult.isOk || !startResult.response.response.isStarted) {
+            const errMsg = !startResult.isOk
+                ? (startResult.message ?? 'Veil start failed')
+                : (startResult.response.response.error ?? 'Veil start failed');
+
+            await this.commandBus.execute(
+                new UpdateNodeCommand({
+                    uuid: node.uuid,
+                    lastStatusMessage: errMsg,
+                    lastStatusChange: new Date(),
+                    isConnected: false,
+                    isConnecting: false,
+                }),
+            );
+
+            this.eventEmitter.emit(EVENTS.NODE.DISCONNECTED, new NodeEvent(node, EVENTS.NODE.DISCONNECTED));
+
+            this.logger.warn(`Veil node ${node.uuid} failed to start: ${errMsg}`);
+            return;
+        }
+
+        await this.rawCacheService.set(
+            CACHE_KEYS.NODE_XRAY_UPTIME(node.uuid),
+            Date.now().toString(),
+            CACHE_KEYS_TTL.NODE_XRAY_UPTIME,
+        );
+
+        await this.commandBus.execute(
+            new UpdateNodeCommand({
+                uuid: node.uuid,
+                isConnected: true,
+                isConnecting: false,
+                lastStatusChange: new Date(),
+                lastStatusMessage: null,
+            }),
+        );
+
+        this.eventEmitter.emit(EVENTS.NODE.CONNECTED, new NodeEvent(node, EVENTS.NODE.CONNECTED));
+
+        this.logger.log(
+            `Veil node ${node.name} (${node.uuid}) connected in ${formatExecutionTime(startTime)}`,
+        );
+    }
+
+    /**
+     * Stub server.yaml generator for VEIL-cored nodes.
+     *
+     * Real version (follow-up PR) reads the node's activeInbounds and
+     * the active config-profile to emit a fully-featured Veil
+     * server.yaml — Reality target_sni, WSS path, QUIC bind, decoy
+     * origin, mimicry profile, etc. Today it emits a minimal three-
+     * transport skeleton on the canonical ports so end-to-end
+     * connectivity can be verified without that machinery in place.
+     */
+    private async buildVeilServerConfig(
+        _node: Awaited<ReturnType<typeof this.queryBus.execute<GetNodeByUuidQuery>>>['response'],
+    ): Promise<string> {
+        return [
+            'transports:',
+            '  - type: reality',
+            '    listen: "0.0.0.0:443"',
+            '    target_sni: www.microsoft.com',
+            '    target_addr: www.microsoft.com:443',
+            '  - type: wss',
+            '    listen: "0.0.0.0:8443"',
+            '    path: "/api/sync"',
+            '  - type: quic',
+            '    listen: "0.0.0.0:8444"',
+            'static_key_path: "/var/lib/veil/server.key"',
+            'user_db_path: "/var/lib/veil/users.db"',
+            '',
+        ].join('\n');
+    }
+
+    private async sha256(input: string): Promise<string> {
+        const { createHash } = await import('node:crypto');
+        return createHash('sha256').update(input).digest('hex');
     }
 }

--- a/src/queue/_nodes/processors/stop-node.processor.ts
+++ b/src/queue/_nodes/processors/stop-node.processor.ts
@@ -44,7 +44,13 @@ export class StopNodeProcessor extends WorkerHost {
                 return true;
             }
 
-            await this.axios.stopXray(result.response.address, result.response.port);
+            // Dispatch by core: VEIL-cored nodes have their own
+            // /node/veil/stop endpoint exposed by remnawave/node.
+            if (result.response.core === 'VEIL') {
+                await this.axios.stopVeil(result.response.address, result.response.port);
+            } else {
+                await this.axios.stopXray(result.response.address, result.response.port);
+            }
 
             // TODO: disable plugins?
 


### PR DESCRIPTION
## Summary

Backend counterpart to **[remnawave/node#38](https://github.com/remnawave/node/pull/38)** (also Draft). Lets operators register a node whose proxy daemon is **[Veil](https://github.com/redstone-md/veil)** instead of Xray. The queue processors that drive node lifecycle dispatch on a new `Nodes.core` enum (`XRAY` | `VEIL`); existing fleets keep their behaviour unchanged because every existing row defaults to `core='XRAY'`.

> **Why Draft.** Two reasons:
> 1. The node-side companion PR is also Draft; `@remnawave/node-contract@>=2.8.0` (which would expose `StartVeilCommand` natively) hasn't been published yet — this PR ships an inline shim with a clear migration TODO.
> 2. Veil itself is pre-alpha (`v0.1.0-alpha.1`) pending its first external audit; we don't want operators landing on this without that context.

## What ships

**Schema**

```prisma
enum NodeCore { XRAY VEIL }

model Nodes {
  ...
  core NodeCore @default(XRAY) @map("core")
  ...
}
```

Migration `20260512000000_add_node_core/migration.sql` — additive, NOT NULL DEFAULT 'XRAY' + index on the column for fast per-node lookups.

**Axios facade** (`src/common/axios/axios.service.ts`) — three counterparts to the existing `startXray` / `stopXray` / `getNodeHealth`:

- `startVeil(data, url, port)` — POST `/node/veil/start` with the same zstd-compressed body shape Xray uses
- `stopVeil(url, port)` — GET `/node/veil/stop`
- `getVeilNodeHealth(url, port)` — GET `/node/veil/healthcheck`

Same `TResult<>` return surface, same `ERRORS.NODE_ERROR_WITH_MSG` mapping, same JWT-bound `axiosInstance` defaults — no new HTTP plumbing.

**Processors**

- `StartNodeProcessor` — branches at `node.core`. The Xray happy-path is byte-identical to today; the VEIL branch goes through a new private `startVeilNode()` that probes `/node/veil/healthcheck`, generates `server.yaml`, pushes via `/node/veil/start`, updates the node row + emits the same `NODE.CONNECTED` / `NODE.DISCONNECTED` events as the Xray path.
- `StopNodeProcessor` — branches the same way (`stopVeil` vs `stopXray`).

**Inline contract shim** (`src/common/veil-contract/veil-commands.ts`) — Zod schemas for the three Veil commands. Mirrors what `@remnawave/node-contract` will expose once the node-side PR lands a new release. The shim is documented as throwaway: a single comment block in the file lists the imports to swap once the package is on npm.

## Deliberately scoped out of this PR

| Concern | Why not now |
|---|---|
| Full `server.yaml` generator that maps the operator's existing inbounds + Reality decoy origins / mimicry profiles / decoy traffic into Veil's schema | The Veil schema isn't stable enough to commit to pre-audit. `buildVeilServerConfig` ships a known-good three-transport skeleton on canonical ports so end-to-end connectivity is verifiable; richer mapping lands in a follow-up. |
| Per-user CRUD on VEIL-cored nodes | Veil exposes `/api/users` on its admin port; the existing `handler/*` processors use Xray's gRPC user-add path. A `VeilUserSyncProcessor` lands in the same follow-up that fleshes out the YAML generator. |
| Frontend changes | Lives in `remnawave/frontend`, separate PR. |
| Per-node stats parsing | `/node/stats/*` is already core-agnostic (system metrics, not Xray-specific) so no change needed in this PR. |

## Backwards compat

Pure addition. Every existing `Nodes` row migrates to `core='XRAY'`. Each branch in the touched processors falls through to the unchanged Xray path for those rows. An operator who never registers a VEIL node sees zero behavioural change. Rolling this out to a fleet that hasn't onboarded VEIL is a no-op deploy.

## Test plan

The repo's existing test infra is integration-shaped (Postgres + Redis + node mocks); rather than spinning up a half-stub I exercised this against a live setup:

- [x] `npx prisma migrate deploy` against a fresh Postgres — migration applies cleanly, `SELECT core FROM nodes` returns `XRAY` for pre-migration rows.
- [x] Registered a node with `core='VEIL'` (manual UPDATE for now until the frontend PR lands the dropdown). `StartNodeProcessor` picks the VEIL branch, probes `/node/veil/healthcheck`, posts `/node/veil/start` with the stub `server.yaml`, node flips to `isConnected=true`.
- [x] Stop → `StopNodeProcessor` calls `stopVeil`, supervisord on the node side stops the `veil` program, node row clears.
- [x] Verified an XRAY-cored node onboarded against the same panel build still uses the unchanged `startXray` path (regression check).

## File map

```
prisma/
  schema.prisma                                                  +9 -0   NodeCore enum + Nodes.core field
  migrations/20260512000000_add_node_core/migration.sql          +18 -0  CREATE TYPE + ALTER TABLE + INDEX
src/
  common/
    axios/axios.service.ts                                       +97 -0  startVeil / stopVeil / getVeilNodeHealth
    veil-contract/veil-commands.ts                               +90 -0  inline shim until node-contract publishes
  modules/nodes/entities/nodes.entity.ts                         +1 -0   public core: 'XRAY' | 'VEIL'
  queue/_nodes/processors/
    start-node.processor.ts                                      +138 -0 VEIL fork + startVeilNode + buildVeilServerConfig + sha256
    stop-node.processor.ts                                       +6 -1   stopVeil branch
```

Total: 7 files changed, +369 / -3.

## Notes for reviewers

- Style: matches existing repo conventions — 4-space indent, alphabetical `@modules` / `@common` / `@libs` import groups, `pRetry` + `AxiosError` failure surface, same logger / event-emitter shapes the Xray processor uses.
- No new top-level dependencies. The veil shim uses `zod` and the SHA-256 helper uses `node:crypto`, both already in the dep tree.
- The shim's enum names + URL paths are pinned to what the node PR exposes; keep them in lock-step if the node side renames.
- Once `@remnawave/node-contract` ships the real namespaces, the veil-contract shim folder gets deleted in a one-line PR (just swap the import).
