### PR TITLE
Remove host remark length limit

### DIFF
--- a/libs/contract/commands/hosts/create.command.ts
+++ b/libs/contract/commands/hosts/create.command.ts
@@ -31,9 +31,6 @@ export namespace CreateHostCommand {
             })
             .min(1, {
                 message: 'Remark must be at least 1 character',
-            })
-            .max(40, {
-                message: 'Remark must be less than 40 characters',
             }),
 
         address: z.string({

--- a/libs/contract/commands/hosts/update.command.ts
+++ b/libs/contract/commands/hosts/update.command.ts
@@ -33,9 +33,6 @@ export namespace UpdateHostCommand {
             .string({
                 invalid_type_error: 'Remark must be a string',
             })
-            .max(40, {
-                message: 'Remark must be less than 40 characters',
-            })
             .optional(),
         address: z
             .string({

--- a/prisma/migrations/20260520223000_remove_host_remark_limit/migration.sql
+++ b/prisma/migrations/20260520223000_remove_host_remark_limit/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "hosts"
+    ALTER COLUMN "remark" SET DATA TYPE TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -259,7 +259,7 @@ model NodesUsageHistory {
 model Hosts {
   uuid                         String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
   viewPosition                 Int      @default(autoincrement()) @map("view_position")
-  remark                       String   @map("remark") @db.VarChar(50)
+  remark                       String   @map("remark")
   address                      String   @map("address")
   port                         Int      @map("port")
   path                         String?  @map("path")


### PR DESCRIPTION
I checked almost all clients and did not find any hard 40-character limits for host names. I think the current limit is unnecessary and sometimes only gets in the way.

For example, I recently wanted to create an experimental configuration, but the 40-character limit made it difficult to describe what the profile was for, so I had to omit or shorten a lot of details.

This PR should remove the limit by updating the backend contract and persistence layer. Frontend builds that consume the updated contract will inherit the relaxed validation.
