### PR TITLE
feat: Add Hysteria2 outbound generation support to subscription templates

### DIFF
--- a/src/modules/subscription-template/generators/singbox.generator.service.ts
+++ b/src/modules/subscription-template/generators/singbox.generator.service.ts
@@ -22,6 +22,12 @@ interface OutboundConfig {
         enabled: boolean;
         version: number;
     };
+    up_mbps?: number;
+    down_mbps?: number;
+    obfs?: {
+        type: string;
+        password: string;
+    };
 }
 
 interface TlsConfig {
@@ -49,9 +55,9 @@ interface TransportConfig {
     type: string;
 }
 
-const UNSUPPORTED_TRANSPORTS = new Set(['hysteria', 'kcp', 'xhttp']);
-const PROXY_PROTOCOL_TYPES = new Set(['hysteria', 'shadowsocks', 'trojan', 'vless']);
-const SELECTOR_TYPES = new Set(['shadowsocks', 'trojan', 'urltest', 'vless']);
+const UNSUPPORTED_TRANSPORTS = new Set(['kcp', 'xhttp']);
+const PROXY_PROTOCOL_TYPES = new Set(['hysteria2', 'shadowsocks', 'trojan', 'vless']);
+const SELECTOR_TYPES = new Set(['hysteria2', 'shadowsocks', 'trojan', 'urltest', 'vless']);
 
 @Injectable()
 export class SingBoxGeneratorService {
@@ -85,8 +91,12 @@ export class SingBoxGeneratorService {
 
     private buildOutbound(host: ResolvedProxyConfig): OutboundConfig | null {
         try {
+            if (host.protocol === 'hysteria' && (host.protocolOptions as any).version !== 2) {
+                return null;
+            }
+
             const config: OutboundConfig = {
-                type: host.protocol,
+                type: host.protocol === 'hysteria' ? 'hysteria2' : host.protocol,
                 tag: host.finalRemark,
                 server: host.address,
                 server_port: host.port,
@@ -112,6 +122,34 @@ export class SingBoxGeneratorService {
 
                 if (host.protocolOptions.flow === 'xtls-rprx-vision') {
                     config.flow = host.protocolOptions.flow;
+                }
+                return true;
+
+            case 'hysteria':
+                config.password = (host.transportOptions as any).auth;
+                
+                if (host.streamOverrides.finalMask) {
+                    const finalMask = host.streamOverrides.finalMask as any;
+                    if (finalMask.quicParams) {
+                        if (finalMask.quicParams.brutalUp) {
+                            const up = parseInt(String(finalMask.quicParams.brutalUp), 10);
+                            if (!isNaN(up)) config.up_mbps = up;
+                        }
+                        if (finalMask.quicParams.brutalDown) {
+                            const down = parseInt(String(finalMask.quicParams.brutalDown), 10);
+                            if (!isNaN(down)) config.down_mbps = down;
+                        }
+                    }
+
+                    if (Array.isArray(finalMask.udp)) {
+                        const obfsPassword = finalMask.udp.find((m: any) => m?.type === 'salamander')?.settings?.password;
+                        if (obfsPassword) {
+                            config.obfs = {
+                                type: 'salamander',
+                                password: obfsPassword,
+                            };
+                        }
+                    }
                 }
                 return true;
 
@@ -240,7 +278,7 @@ export class SingBoxGeneratorService {
             config.server_name = opts.serverName;
         }
 
-        if (opts.fingerprint) {
+        if (opts.fingerprint && host.protocol !== 'hysteria') {
             config.utls = {
                 enabled: true,
                 fingerprint: opts.fingerprint,


### PR DESCRIPTION
This PR adds Hysteria2 outbound generation support to the Sing-box generator, allowing users to utilize Hysteria2 nodes with full template features like routing rules. (Resubmitted after addressing Xray mapping feedback).