### PR TITLE
feat(hosts): add pinnedPeerCertSha256 field support

### DIFF
--- a/libs/contract/commands/hosts/create.command.ts
+++ b/libs/contract/commands/hosts/create.command.ts
@@ -84,6 +84,18 @@ export namespace CreateHostCommand {
         vlessRouteId: z.optional(z.number().int().min(0).max(65535).nullable()),
         shuffleHost: z.optional(z.boolean().default(false)),
         mihomoX25519: z.optional(z.boolean().default(false)),
+        pinnedPeerCertSha256: z
+            .optional(
+                z
+                    .string()
+                    .max(64, {
+                        message: 'Pinned peer cert SHA256 must be less than 64 characters',
+                    })
+                    .nullable(),
+            )
+            .describe(
+                'Optional. SHA256 hash of the server certificate for certificate pinning. Used for self-signed certificates.',
+            ),
         nodes: z.optional(z.array(z.string().uuid())),
         xrayJsonTemplateUuid: z.optional(z.string().uuid().nullable()),
         excludedInternalSquads: z

--- a/libs/contract/commands/hosts/update.command.ts
+++ b/libs/contract/commands/hosts/update.command.ts
@@ -88,6 +88,18 @@ export namespace UpdateHostCommand {
         allowInsecure: z.optional(z.boolean()),
         shuffleHost: z.optional(z.boolean()),
         mihomoX25519: z.optional(z.boolean()),
+        pinnedPeerCertSha256: z
+            .optional(
+                z
+                    .string()
+                    .max(64, {
+                        message: 'Pinned peer cert SHA256 must be less than 64 characters',
+                    })
+                    .nullable(),
+            )
+            .describe(
+                'Optional. SHA256 hash of the server certificate for certificate pinning. Used for self-signed certificates.',
+            ),
         nodes: z.optional(z.array(z.string().uuid())),
         xrayJsonTemplateUuid: z.optional(z.string().uuid().nullable()),
         excludedInternalSquads: z

--- a/libs/contract/models/hosts.schema.ts
+++ b/libs/contract/models/hosts.schema.ts
@@ -33,6 +33,7 @@ export const HostsSchema = z.object({
     keepSniBlank: z.boolean().default(false),
     vlessRouteId: z.number().int().min(0).max(65535).nullable(),
     allowInsecure: z.boolean().default(false),
+    pinnedPeerCertSha256: z.string().nullable(),
     shuffleHost: z.boolean(),
     mihomoX25519: z.boolean(),
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -276,6 +276,7 @@ model Hosts {
   serverDescription            String?  @map("server_description") @db.VarChar(30)
   vlessRouteId                 Int?     @map("vless_route_id")
   allowInsecure                Boolean  @default(false) @map("allow_insecure")
+  pinnedPeerCertSha256         String?  @map("pinned_peer_cert_sha256")
   shuffleHost                  Boolean  @default(false) @map("shuffle_host")
   mihomoX25519                 Boolean  @default(false) @map("mihomo_x25519")
   xrayJsonTemplateUuid         String?  @map("xray_json_template_uuid") @db.Uuid

--- a/src/modules/hosts/entities/hosts.entity.ts
+++ b/src/modules/hosts/entities/hosts.entity.ts
@@ -25,6 +25,7 @@ export class HostsEntity implements Hosts {
     isDisabled: boolean;
     serverDescription: null | string;
     allowInsecure: boolean;
+    pinnedPeerCertSha256: null | string;
 
     tag: null | string;
     isHidden: boolean;

--- a/src/modules/subscription-template/generators/xray-json.generator.service.ts
+++ b/src/modules/subscription-template/generators/xray-json.generator.service.ts
@@ -153,6 +153,10 @@ function buildTlsSettings(host: ResolvedProxyConfig): Record<string, unknown> {
         settings.allowInsecure = true;
     }
 
+    if (host.securityOptions.pinnedPeerCertSha256) {
+        settings.pinnedPeerCertSha256 = host.securityOptions.pinnedPeerCertSha256;
+    }
+
     return settings;
 }
 

--- a/src/modules/subscription-template/resolve-proxy/interfaces/resolved-proxy-config.interface.ts
+++ b/src/modules/subscription-template/resolve-proxy/interfaces/resolved-proxy-config.interface.ts
@@ -78,6 +78,7 @@ export interface ITlsSecurityOptions {
     serverName: string | null;
     echConfigList: string | null;
     echForceQuery: string | null;
+    pinnedPeerCertSha256: string | null;
 }
 
 export interface IRealitySecurityOptions {

--- a/src/modules/subscription-template/resolve-proxy/resolve-proxy-config.service.ts
+++ b/src/modules/subscription-template/resolve-proxy/resolve-proxy-config.service.ts
@@ -389,6 +389,7 @@ export class ResolveProxyConfigService {
                         ),
                         echConfigList: tls?.echConfigList || null,
                         echForceQuery: tls?.echForceQuery || null,
+                        pinnedPeerCertSha256: inputHost.pinnedPeerCertSha256 || null,
                     },
                 };
             }


### PR DESCRIPTION


xray-core v26.1.31 removed allowInsecure and replaced it with 
pinnedPeerCertSha256 for self-signed certificate verification.

This PR adds pinnedPeerCertSha256 support to the Hosts configuration
so users with self-signed certificates can use certificate pinning
instead of the removed allowInsecure option.

Changes:
- schema.prisma: added pinned_peer_cert_sha256 field to hosts table
- hosts.entity.ts: added pinnedPeerCertSha256 property
- hosts.schema.ts: added field to Zod schema
- create.command.ts: added optional pinnedPeerCertSha256 field
- update.command.ts: added optional pinnedPeerCertSha256 field
- resolved-proxy-config.interface.ts: added to ITlsSecurityOptions
- resolve-proxy-config.service.ts: passing value from Host
- xray-json.generator.service.ts: added to generated tlsSettings