### PR TITLE
fix: use full pinnedPeerCertSha256 key in xray-json tlsSettings

### DIFF
--- a/src/modules/subscription-template/generators/xray-json.generator.service.ts
+++ b/src/modules/subscription-template/generators/xray-json.generator.service.ts
@@ -151,7 +151,7 @@ function buildTlsSettings(host: ResolvedProxyConfig): Record<string, unknown> {
     }
 
     if (host.securityOptions.pinnedPeerCertSha256) {
-        settings.pcs = host.securityOptions.pinnedPeerCertSha256;
+        settings.pinnedPeerCertSha256 = host.securityOptions.pinnedPeerCertSha256;
     }
 
     if (host.securityOptions.echForceQuery) {


### PR DESCRIPTION
## Fix: Correct pinnedPeerCertSha256 field name in Xray JSON subscription

### Issue
The `pinnedPeerCertSha256` field was being serialized as `pcs` (abbreviated form) in Xray JSON subscription output instead of using the full parameter name `pinnedPeerCertSha256` as expected by Xray core.

### Root Cause
In `xray-json.generator.service.ts`, the `buildTlsSettings()` function was using the abbreviated key name `settings.pcs` instead of the full key name `settings.pinnedPeerCertSha256`.

### Changes
- **File:** `src/modules/subscription-template/generators/xray-json.generator.service.ts`
- **Line 154:** Changed `settings.pcs` to `settings.pinnedPeerCertSha256`

### Result
Generated Xray JSON configs now correctly include:
```json
"tlsSettings": {
  "serverName": "example.com",
  "fingerprint": "chrome",
  "pinnedPeerCertSha256": "2fa46683a1318d619e2637826b33460b8e510448f9ce9ccbd1ebb06806c824ed"
}