### PR TITLE
fix(subscription): encode share-link query with %20 instead of + (iOS sni/host bug)

### DIFF
--- a/src/modules/subscription-template/generators/xray.generator.service.ts
+++ b/src/modules/subscription-template/generators/xray.generator.service.ts
@@ -392,10 +392,6 @@ export class XrayGeneratorService {
 
         for (const [key, value] of Object.entries(params)) {
             if (value === undefined || value === null) continue;
-            // Use encodeURIComponent (RFC 3986) so a space becomes %20.
-            // URLSearchParams.toString() serializes as x-www-form-urlencoded,
-            // turning a space into '+', which iOS clients parse as a literal '+'
-            // in sni/host instead of a space — breaking the share link.
             parts.push(`${encodeURIComponent(key)}=${encodeURIComponent(String(value))}`);
         }
 

--- a/src/modules/subscription-template/generators/xray.generator.service.ts
+++ b/src/modules/subscription-template/generators/xray.generator.service.ts
@@ -388,13 +388,17 @@ export class XrayGeneratorService {
     // ── Query String Builder ─────────────────────────
 
     private buildQueryString(params: Record<string, unknown>): string {
-        const stringParams: Record<string, string> = {};
+        const parts: string[] = [];
 
         for (const [key, value] of Object.entries(params)) {
             if (value === undefined || value === null) continue;
-            stringParams[key] = String(value);
+            // Use encodeURIComponent (RFC 3986) so a space becomes %20.
+            // URLSearchParams.toString() serializes as x-www-form-urlencoded,
+            // turning a space into '+', which iOS clients parse as a literal '+'
+            // in sni/host instead of a space — breaking the share link.
+            parts.push(`${encodeURIComponent(key)}=${encodeURIComponent(String(value))}`);
         }
 
-        return new URLSearchParams(stringParams).toString();
+        return parts.join('&');
     }
 }


### PR DESCRIPTION
## Problem

When a host's `sni` (or transport `host`) value accidentally contains a space, the generated VLESS/Trojan **share link** comes out malformed on iOS clients: the space turns into a literal `+` (e.g. `sni=example .com` в†’ parsed as `example+.com`).

### Root cause

`XrayGeneratorService.buildQueryString()` builds the query via:

```ts
return new URLSearchParams(stringParams).toString();
```

`URLSearchParams.toString()` serializes as `application/x-www-form-urlencoded`, which encodes a space as `+` (not `%20`).

A share-link query is a regular RFC 3986 URI query. Clients diverge on decoding it:

- Android clients tend to decode the query as form-urlencoded, so `+` в†’ space (value still wrong, but no visible `+`).
- iOS (`URLComponents` / standard RFC 3986 decoding) treats `+` as a **literal plus**, so `sni`/`host` ends up containing a `+` character вЂ” corrupting the link.

## Fix

Build the query manually with `encodeURIComponent` (RFC 3986), so a space becomes `%20`, which every client (including iOS) decodes back to a space consistently.

```ts
private buildQueryString(params: Record<string, unknown>): string {
    const parts: string[] = [];
    for (const [key, value] of Object.entries(params)) {
        if (value === undefined || value === null) continue;
        parts.push(`${encodeURIComponent(key)}=${encodeURIComponent(String(value))}`);
    }
    return parts.join('&');
}
```

### Compatibility

The only meaningful change in output is space `+` в†’ `%20`. Other values encode identically вЂ” `URLSearchParams` already percent-encodes `/` to `%2F`, etc. The few characters `! ~ ' ( )` are now left raw instead of percent-encoded; all are valid in a URI query component per RFC 3986, so no client breakage.

### Note (out of scope)

This fixes the encoding so the link is consistent across platforms. It does **not** sanitize the input вЂ” a stray space in `sni`/`host` still yields an invalid server name (now `%20` everywhere instead of `+` on iOS). Trimming `sni`/`host` on input would be a good complementary follow-up.
