### PR TITLE
fix(config-profiles): restart nodes on snippet create/update/delete

### DIFF
--- a/src/common/helpers/xray-config/xray-config.validator.ts
+++ b/src/common/helpers/xray-config/xray-config.validator.ts
@@ -314,6 +314,29 @@ export class XRayConfig {
         }
     }
 
+    public getReferencedSnippetNames(): Set<string> {
+        const names = new Set<string>();
+
+        this.collectSnippetNames(this.config.outbounds, names);
+        this.collectSnippetNames(this.config.routing?.rules, names);
+        this.collectSnippetNames(this.config.routing?.balancers, names);
+
+        return names;
+    }
+
+    private collectSnippetNames(
+        array: RoutingRule[] | BalancingRule[] | undefined,
+        names: Set<string>,
+    ): void {
+        if (!array) return;
+
+        for (const item of array) {
+            if (typeof item.snippet === 'string') {
+                names.add(item.snippet);
+            }
+        }
+    }
+
     public replaceSnippets(snippets: Map<string, unknown>): void {
         if (this.config.outbounds) {
             this.replaceSnippetsInArray(this.config.outbounds, snippets);

--- a/src/modules/config-profiles/snippets.service.ts
+++ b/src/modules/config-profiles/snippets.service.ts
@@ -2,9 +2,13 @@ import { PrismaClientKnownRequestError } from '@prisma/client/runtime/library';
 
 import { Injectable, Logger } from '@nestjs/common';
 
+import { XRayConfig } from '@common/helpers/xray-config';
 import { fail, ok, TResult } from '@common/types';
 import { ERRORS } from '@libs/contracts/constants/errors';
 
+import { NodesQueuesService } from '@queue/_nodes';
+
+import { ConfigProfileRepository } from './repositories/config-profile.repository';
 import { SnippetsRepository } from './repositories/snippets.repository';
 import { GetSnippetsResponseModel } from './models';
 import { SnippetEntity } from './entities';
@@ -13,7 +17,45 @@ import { SnippetEntity } from './entities';
 export class SnippetsService {
     private readonly logger = new Logger(SnippetsService.name);
 
-    constructor(private readonly snippetsRepository: SnippetsRepository) {}
+    constructor(
+        private readonly snippetsRepository: SnippetsRepository,
+        private readonly configProfileRepository: ConfigProfileRepository,
+        private readonly nodesQueuesService: NodesQueuesService,
+    ) {}
+
+    private async restartNodesUsingSnippet(name: string, emitter: string): Promise<void> {
+        try {
+            const configProfiles = await this.configProfileRepository.getAllConfigProfiles();
+
+            for (const configProfile of configProfiles) {
+                let referencedSnippets: Set<string>;
+
+                try {
+                    referencedSnippets = new XRayConfig(
+                        configProfile.config as object,
+                    ).getReferencedSnippetNames();
+                } catch (error) {
+                    this.logger.error(
+                        `Failed to parse config of profile ${configProfile.uuid} while resolving snippet usage: ${error}`,
+                    );
+                    continue;
+                }
+
+                if (!referencedSnippets.has(name)) {
+                    continue;
+                }
+
+                await this.nodesQueuesService.startAllNodesByProfile({
+                    profileUuid: configProfile.uuid,
+                    emitter,
+                });
+            }
+        } catch (error) {
+            // The snippet mutation itself already succeeded, so a failure to
+            // enqueue node restarts must not fail the request.
+            this.logger.error(`Failed to restart nodes after snippet "${name}" change: ${error}`);
+        }
+    }
 
     public async getSnippets(): Promise<TResult<GetSnippetsResponseModel>> {
         try {
@@ -35,6 +77,8 @@ export class SnippetsService {
             }
 
             await this.snippetsRepository.deleteByName(name);
+
+            await this.restartNodesUsingSnippet(name, 'deleteSnippetByName');
 
             return await this.getSnippets();
         } catch (error) {
@@ -62,6 +106,8 @@ export class SnippetsService {
             });
 
             await this.snippetsRepository.create(snippetEntity);
+
+            await this.restartNodesUsingSnippet(name, 'createSnippet');
 
             return await this.getSnippets();
         } catch (error) {
@@ -106,6 +152,8 @@ export class SnippetsService {
             });
 
             await this.snippetsRepository.update(snippetEntity);
+
+            await this.restartNodesUsingSnippet(name, 'updateSnippet');
 
             return await this.getSnippets();
         } catch (error) {


### PR DESCRIPTION
## Description

Snippets are expanded into the node config at generation time via `XRayConfig.replaceSnippets()` (see `get-prepared-config-with-users.handler.ts`). However, creating, updating or deleting a snippet did not trigger any node restart — unlike updating a config profile, which calls `startAllNodesByProfile`.

As a result, after editing a snippet the panel saved the new value but nodes kept serving the **old** config until a manual node restart.

## Fix

Trigger `nodesQueuesService.startAllNodes()` after snippet `create`, `update` and `delete` in `SnippetsService`, so the regenerated config (with the new snippet values) is propagated to nodes automatically.

Since snippets are global and may be referenced by any config profile, `startAllNodes` is used rather than restarting a single profile's nodes.

Closes remnawave/panel#398