### PR TITLE
feat: add age encryption for MIHOMO subscriptions

### DIFF
--- a/libs/contract/models/response-rules/response-rule-modifications.schema.ts
+++ b/libs/contract/models/response-rules/response-rule-modifications.schema.ts
@@ -108,6 +108,27 @@ export const ResponseRuleModificationsSchema = z
                         '**Example:** `["^MyClient/", "^CustomApp\\\\/v2"]`',
                 }),
             ),
+        agePublicKey: z
+            .string()
+            .regex(
+                /^age1[a-z0-9]+$/,
+                'Invalid age public key. Must start with "age1" (x25519) or "age1pq1" (post-quantum).',
+            )
+            .optional()
+            .describe(
+                JSON.stringify({
+                    markdownDescription:
+                        '**Age public key (recipient)** for encrypting the MIHOMO response.\n\n' +
+                        '**Only works when `responseType` is `MIHOMO`.**\n\n' +
+                        '**Server:** encrypts YAML config with this public key.\n\n' +
+                        '**Client (v1.19.27 core):** must have the corresponding ' +
+                        '`AGE-SECRET-KEY-1...` in its `age-secret-key` field to decrypt.\n\n' +
+                        '**Key generation:**\n' +
+                        '- x25519: `mihomo age keygen` → public key starts with `age1`\n' +
+                        '- Post-quantum: `mihomo age keygen-pq` → public key starts with `age1pq1`\n\n' +
+                        '**Format:** `age1<bech32>` or `age1pq1<bech32>`',
+                }),
+            ),
     })
     .optional()
     .describe(

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "@stablelib/base64": "^2.0.1",
     "@stablelib/x25519": "^2.0.1",
     "@willsoto/nestjs-prometheus": "^6.1.0",
+    "age-encryption": "^1.0.0",
     "arctic": "^3.7.0",
     "axios": "^1.16.1",
     "bullmq": "5.77.6",

--- a/src/modules/subscription-response-rules/interfaces/srr-context.ts
+++ b/src/modules/subscription-response-rules/interfaces/srr-context.ts
@@ -14,4 +14,5 @@ export interface ISRRContext {
     ignoreHostXrayJsonTemplate?: boolean;
     headersToApply?: Record<string, string>;
     ignoreServeJsonAtBaseSubscription?: boolean;
+    agePublicKey?: string;
 }

--- a/src/modules/subscription-response-rules/middleware/response-rules.middleware.ts
+++ b/src/modules/subscription-response-rules/middleware/response-rules.middleware.ts
@@ -113,6 +113,12 @@ export class ResponseRulesMiddleware implements NestMiddleware {
                 if (mods.ignoreServeJsonAtBaseSubscription) {
                     ssrContext.ignoreServeJsonAtBaseSubscription = true;
                 }
+                if (
+                    mods.agePublicKey &&
+                    ssrContext.matchedResponseType === RESPONSE_RULES_RESPONSE_TYPES.MIHOMO
+                ) {
+                    ssrContext.agePublicKey = mods.agePublicKey;
+                }
             }
 
             switch (ssrContext.matchedResponseType) {

--- a/src/modules/subscription-response-rules/services/response-rules-parser.service.ts
+++ b/src/modules/subscription-response-rules/services/response-rules-parser.service.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { Encrypter } from 'age-encryption';
 
 import { Injectable, Logger } from '@nestjs/common';
 
@@ -19,7 +20,7 @@ export class ResponseRulesParserService {
                 );
             }
 
-            this.validateRules(config.data);
+            await this.validateRules(config.data);
 
             return config.data;
         } catch (error) {
@@ -43,7 +44,7 @@ export class ResponseRulesParserService {
         }
     }
 
-    private validateRules(config: TResponseRulesConfig): void {
+    private async validateRules(config: TResponseRulesConfig): Promise<void> {
         for (const rule of config.rules) {
             for (const condition of rule.conditions) {
                 if (condition.operator === 'REGEX' || condition.operator === 'NOT_REGEX') {
@@ -65,6 +66,22 @@ export class ResponseRulesParserService {
                     } catch {
                         throw new Error(`Invalid regex in rule "${rule.name}": ${regex}`);
                     }
+                }
+            }
+
+            if (rule.responseModifications?.agePublicKey) {
+                if (rule.responseType !== 'MIHOMO') {
+                    throw new Error(
+                        `Rule "${rule.name}": agePublicKey is only supported for responseType "MIHOMO"`,
+                    );
+                }
+                try {
+                    const enc = new Encrypter();
+                    enc.addRecipient(rule.responseModifications.agePublicKey);
+                } catch {
+                    throw new Error(
+                        `Rule "${rule.name}": invalid agePublicKey — cannot create age recipient`,
+                    );
                 }
             }
         }

--- a/src/modules/subscription-template/generators/mihomo.generator.service.ts
+++ b/src/modules/subscription-template/generators/mihomo.generator.service.ts
@@ -1,5 +1,6 @@
 import yaml from 'yaml';
 import _ from 'lodash';
+import { Encrypter, armor } from 'age-encryption';
 
 import { Injectable, Logger } from '@nestjs/common';
 
@@ -112,6 +113,7 @@ export class MihomoGeneratorService {
         isStash = false,
         isExtendedClient = false,
         overrideTemplateName?: string,
+        agePublicKey?: string,
     ): Promise<string> {
         try {
             const yamlConfigDb = await this.subscriptionTemplateService.getCachedTemplateByType(
@@ -145,9 +147,27 @@ export class MihomoGeneratorService {
                 proxyRemarks.push(host.finalRemark);
             }
 
-            return await this.renderConfig(data, proxyRemarks, cleanConfig);
+            const yamlOutput = await this.renderConfig(data, proxyRemarks, cleanConfig);
+
+            if (agePublicKey && yamlOutput) {
+                return await this.encryptWithAge(yamlOutput, agePublicKey);
+            }
+
+            return yamlOutput;
         } catch (error) {
             this.logger.error('Error generating clash config:', error);
+            return '';
+        }
+    }
+
+    private async encryptWithAge(content: string, publicKey: string): Promise<string> {
+        try {
+            const enc = new Encrypter();
+            enc.addRecipient(publicKey);
+            const encrypted = await enc.encrypt(content);
+            return armor.encode(encrypted);
+        } catch (error) {
+            this.logger.error('Error encrypting MIHOMO config with age:', error);
             return '';
         }
     }

--- a/src/modules/subscription-template/render-templates.service.ts
+++ b/src/modules/subscription-template/render-templates.service.ts
@@ -67,6 +67,7 @@ export class RenderTemplatesService {
                         false,
                         srrContext.isExtendedClient,
                         srrContext.overrideTemplateName,
+                        srrContext.agePublicKey,
                     ),
                     contentType: SUBSCRIPTION_CONFIG_TYPES['MIHOMO'].CONTENT_TYPE,
                 };


### PR DESCRIPTION
Adds support for encrypting MIHOMO subscription configs using the [age](https://age-encryption.org/) format.
When a response rule matches and has `agePublicKey` set in `responseModifications`, the server encrypts
the generated YAML with the specified age public key before returning it to the client with core v1.19.27+.

> **Mihomo core documentation:** https://wiki.metacubex.one/en/config/proxy-providers/?h=proxy#age-secret-key

---

### How it works

1. **Server** holds the **public key** (`age1...`) — used to encrypt the YAML config.
2. **Client** holds the **secret key** (`AGE-SECRET-KEY-1...`) — used to decrypt the response.
3. The encrypted response is returned as ASCII-armored age format (`-----BEGIN AGE ENCRYPTED FILE-----`).

Both key types are supported:
- **x25519** — generated with `mihomo age keygen` → public key starts with `age1`
- **Post-quantum (mlkem768-x25519)** — generated with `mihomo age keygen-pq` → public key starts with `age1pq1`

On encryption error the server returns an empty response (no plaintext fallback).