### PR TITLE
Fix Mihomo Hysteria2 Gecko obfs mapping

### DIFF
--- a/src/common/utils/index.ts
+++ b/src/common/utils/index.ts
@@ -6,3 +6,4 @@ export * from './mask-string';
 export * from './md5';
 export * from './superjson';
 export * from './truncate-header.util';
+export * from './parse-int-range.util';

--- a/src/common/utils/parse-int-range.util.ts
+++ b/src/common/utils/parse-int-range.util.ts
@@ -1,0 +1,26 @@
+export interface IntRange {
+    from: number | null;
+    to: number | null;
+}
+
+export function parseIntRangeUtil(value: string | number | undefined): IntRange {
+    if (value === undefined || value === '') return { from: null, to: null };
+
+    const [left, right = left] = String(value).split('-', 2);
+    const from = parseIntPart(left);
+    const to = parseIntPart(right);
+
+    if (from !== null && to !== null && from > to) {
+        return { from: to, to: from };
+    }
+
+    return { from, to };
+}
+
+function parseIntPart(part: string): number | null {
+    if (part === '') return null;
+
+    const parsed = Number(part);
+
+    return Number.isInteger(parsed) && parsed >= 0 ? parsed : null;
+}

--- a/src/modules/subscription-template/generators/mihomo.generator.service.ts
+++ b/src/modules/subscription-template/generators/mihomo.generator.service.ts
@@ -43,7 +43,7 @@ interface Hysteria2FinalMask {
     };
     udp?: Array<{
         type?: string;
-        settings?: { password?: string };
+        settings?: { packetSize?: string | number; password?: string };
     }>;
 }
 
@@ -647,12 +647,43 @@ export class MihomoGeneratorService {
     private buildHysteria2ObfsFields(
         finalMask: Record<string, unknown> | null,
     ): Record<string, unknown> {
-        const password = (finalMask as Hysteria2FinalMask | null)?.udp?.find(
-            (m) => m?.type === 'salamander',
-        )?.settings?.password;
+        const mask = (finalMask as Hysteria2FinalMask | null)?.udp?.find(
+            (m) => m?.type === 'salamander' || m?.type === 'gecko',
+        );
+        const password = mask?.settings?.password;
 
-        if (!password) return {};
-        return { obfs: 'salamander', 'obfs-password': password };
+        if (!mask || !password) return {};
+
+        const packetSizeFields = this.buildHysteria2PacketSizeFields(mask.settings?.packetSize);
+
+        if (mask.type !== 'gecko' && Object.keys(packetSizeFields).length === 0) {
+            return { obfs: 'salamander', 'obfs-password': password };
+        }
+
+        return {
+            obfs: 'gecko',
+            'obfs-password': password,
+            ...packetSizeFields,
+        };
+    }
+
+    private buildHysteria2PacketSizeFields(packetSize?: string | number): Record<string, unknown> {
+        if (!packetSize) return {};
+
+        const parts = String(packetSize).split('-', 2);
+        const [min, max] = parts;
+        const effectiveMax = parts.length === 1 ? min : max;
+        const minPacketSize = Number(min);
+        const maxPacketSize = Number(effectiveMax);
+
+        return {
+            ...(min && Number.isFinite(minPacketSize) && minPacketSize > 0 && {
+                'obfs-min-packet-size': minPacketSize,
+            }),
+            ...(effectiveMax && Number.isFinite(maxPacketSize) && maxPacketSize > 0 && {
+                'obfs-max-packet-size': maxPacketSize,
+            }),
+        };
     }
 
     private buildHysteria2TlsFields(host: ResolvedProxyConfig): Record<string, unknown> {

--- a/src/modules/subscription-template/generators/mihomo.generator.service.ts
+++ b/src/modules/subscription-template/generators/mihomo.generator.service.ts
@@ -3,7 +3,7 @@ import yaml from 'yaml';
 
 import { Injectable, Logger } from '@nestjs/common';
 
-import { isNonEmptyObject } from '@common/utils';
+import { isNonEmptyObject, parseIntRangeUtil } from '@common/utils';
 import { FINGERPRINTS } from '@libs/contracts/constants';
 
 import { SubscriptionTemplateService } from '@modules/subscription-template/subscription-template.service';
@@ -41,11 +41,24 @@ interface Hysteria2FinalMask {
         bbrProfile?: string;
         congestion?: string;
     };
-    udp?: Array<{
-        type?: string;
-        settings?: { packetSize?: string | number; password?: string };
-    }>;
 }
+
+interface Hysteria2Mask {
+    type: 'salamander';
+    settings: {
+        packetSize?: string | number;
+        password: string;
+    };
+}
+
+interface Hysteria2PacketSizeFields {
+    'obfs-max-packet-size': number;
+    'obfs-min-packet-size': number;
+}
+
+type Hysteria2ObfsFields =
+    | ({ obfs: 'gecko'; 'obfs-password': string } & Partial<Hysteria2PacketSizeFields>)
+    | { obfs: 'salamander'; 'obfs-password': string };
 
 interface ProxyNode {
     [key: string]: unknown;
@@ -646,43 +659,24 @@ export class MihomoGeneratorService {
 
     private buildHysteria2ObfsFields(
         finalMask: Record<string, unknown> | null,
-    ): Record<string, unknown> {
-        const mask = (finalMask as Hysteria2FinalMask | null)?.udp?.find(
-            (m) => m?.type === 'salamander' || m?.type === 'gecko',
-        );
-        const password = mask?.settings?.password;
+    ): Hysteria2ObfsFields | Record<string, never> {
+        const mask = this.findHysteria2Mask(finalMask);
 
-        if (!mask || !password) return {};
+        if (!mask) return {};
 
-        const packetSizeFields = this.buildHysteria2PacketSizeFields(mask.settings?.packetSize);
+        const { password, packetSize } = mask.settings;
 
-        if (mask.type !== 'gecko' && Object.keys(packetSizeFields).length === 0) {
+        if (!packetSize) {
             return { obfs: 'salamander', 'obfs-password': password };
         }
+
+        const { from, to } = parseIntRangeUtil(packetSize);
 
         return {
             obfs: 'gecko',
             'obfs-password': password,
-            ...packetSizeFields,
-        };
-    }
-
-    private buildHysteria2PacketSizeFields(packetSize?: string | number): Record<string, unknown> {
-        if (!packetSize) return {};
-
-        const parts = String(packetSize).split('-', 2);
-        const [min, max] = parts;
-        const effectiveMax = parts.length === 1 ? min : max;
-        const minPacketSize = Number(min);
-        const maxPacketSize = Number(effectiveMax);
-
-        return {
-            ...(min && Number.isFinite(minPacketSize) && minPacketSize > 0 && {
-                'obfs-min-packet-size': minPacketSize,
-            }),
-            ...(effectiveMax && Number.isFinite(maxPacketSize) && maxPacketSize > 0 && {
-                'obfs-max-packet-size': maxPacketSize,
-            }),
+            ...(from && { 'obfs-min-packet-size': from }),
+            ...(to && { 'obfs-max-packet-size': to }),
         };
     }
 
@@ -708,5 +702,44 @@ export class MihomoGeneratorService {
                 target[dst] = asString ? String(source[src]) : source[src];
             }
         }
+    }
+
+    private findHysteria2Mask(finalMask: Record<string, unknown> | null): Hysteria2Mask | null {
+        const udp = finalMask?.udp;
+
+        if (!Array.isArray(udp)) return null;
+
+        return udp.find((mask): mask is Hysteria2Mask => this.isHysteria2Mask(mask)) ?? null;
+    }
+
+    private isHysteria2Mask(value: unknown): value is Hysteria2Mask {
+        if (
+            typeof value !== 'object' ||
+            value === null ||
+            !('type' in value) ||
+            !('settings' in value)
+        ) {
+            return false;
+        }
+
+        if (value.type !== 'salamander') {
+            return false;
+        }
+
+        const settings: unknown = value.settings;
+        if (typeof settings !== 'object' || settings === null || !('password' in settings)) {
+            return false;
+        }
+
+        if (typeof settings.password !== 'string' || settings.password.length === 0) {
+            return false;
+        }
+
+        const packetSize: unknown = 'packetSize' in settings ? settings.packetSize : undefined;
+        return (
+            packetSize === undefined ||
+            typeof packetSize === 'string' ||
+            typeof packetSize === 'number'
+        );
     }
 }


### PR DESCRIPTION
Maps Hysteria2 finalmask packetSize obfs to Mihomo Gecko fields.

Keeps plain Salamander output unchanged when packetSize is not set.