### PR TITLE
fix(subscription): serve InHive full Xray config instead of stripped Sing-box

### DIFF
--- a/prisma/seed/default/response-rules.ts
+++ b/prisma/seed/default/response-rules.ts
@@ -62,7 +62,7 @@ export const SRR_DEFAULT_CONFIG = {
                 {
                     headerName: 'user-agent',
                     operator: 'REGEX',
-                    value: '^sfa|sfi|sfm|sft|karing|singbox|inhive',
+                    value: '^sfa|sfi|sfm|sft|karing|singbox',
                     caseSensitive: false,
                 },
             ],

--- a/src/modules/subscription-template/constants/extended-clients.ts
+++ b/src/modules/subscription-template/constants/extended-clients.ts
@@ -4,6 +4,7 @@ export const EXTENDED_CLIENTS_REGEXES = [
     /^prizrak-box\//,
     /^koala-clash\//,
     /^Happ\//,
+    /^InHive\//,
     /^INCY\//,
 ] as const;
 
@@ -14,6 +15,7 @@ export function isExtendedClient(userAgent: string): boolean {
 export const JSON_SUBSCRIPTION_FALLBACK_CLIENTS = [
     /^[Ss]treisand/,
     /^Happ\//,
+    /^InHive\//,
     /^INCY\//,
     /^ktor-client/,
     /^V2Box/,


### PR DESCRIPTION
## What

Two changes:
1. `prisma/seed/default/response-rules.ts` — remove `inhive` from the default "Sing-box clients" UA regex (mirrors the revert in `remnawave/templates`; this is the copy that seeds fresh panels).
2. `src/modules/subscription-template/constants/extended-clients.ts` — add `/^InHive\//` to `JSON_SUBSCRIPTION_FALLBACK_CLIENTS` and `EXTENDED_CLIENTS_REGEXES`.

## Why

InHive is a universal client (a sing-box fork with Xray parity) whose parser natively ingests raw share-links and Xray-JSON. The Sing-box generator strips `xhttp`/`kcp`/Hysteria-v1 (`UNSUPPORTED_TRANSPORTS`) to protect vanilla sing-box clients — correct for them, but it silently drops nodes for InHive. Removing InHive from that regex lets it fall through to `XRAY_BASE64` (no transport filter); the fallback-clients entry upgrades it to `XRAY_JSON` when the operator has `serveJsonAtBaseSubscription` enabled — the same treatment Happ already gets. `XRAY_JSON` carries the full transport set (no `UNSUPPORTED_TRANSPORTS` in `xray-json.generator.service.ts`).

## Security context

InHive is the only client with per-install localhost proxy authentication, so exit IPs can't be read by a co-resident malicious app — the concern that makes some operators wary of exposing bypass nodes to unknown clients does not apply here.

## Scope / notes

- Client presence/catalog + logo (panel #491) is unaffected and stays. This is purely response-format routing.
- Existing panels keep their response rules in the DB and are not re-seeded, so change (1) affects fresh installs; live operators can drop `|inhive` from their "Sing-box clients" rule manually. Change (2) takes effect immediately for panels on this version once InHive lands on the base `XRAY_BASE64` rule.