### PR TITLE
fix(subscription): emit standard hysteria2 obfs params in xray link generator (salamander)

### DIFF
--- a/src/modules/subscription-template/generators/xray.generator.service.ts
+++ b/src/modules/subscription-template/generators/xray.generator.service.ts
@@ -2,6 +2,13 @@ import { Injectable, Logger } from '@nestjs/common';
 
 import { ResolvedProxyConfig } from '../resolve-proxy/interfaces';
 
+interface Hysteria2FinalMask {
+    udp?: Array<{
+        type?: string;
+        settings?: { password?: string };
+    }>;
+}
+
 /**
  * Generates VLESS/Trojan/Shadowsocks share links per the standard:
  * https://github.com/XTLS/Xray-core/discussions/716
@@ -143,6 +150,16 @@ export class XrayGeneratorService {
             }
         }
 
+        // Salamander obfs — standard hysteria2 URI params (mirrors the mihomo
+        // generator). Emitted IN ADDITION to the proprietary `fm` param so that
+        // standard (non-Happ) hysteria2 clients can connect to salamander-obfs
+        // nodes. See https://v2.hysteria.network/docs/developers/URI-Scheme/
+        const obfsPassword = this.parseSalamanderPassword(host.streamOverrides.finalMask);
+        if (obfsPassword) {
+            params.obfs = 'salamander';
+            params['obfs-password'] = obfsPassword;
+        }
+
         if (host.streamOverrides.finalMask) {
             params.fm = JSON.stringify(host.streamOverrides.finalMask);
         }
@@ -153,6 +170,16 @@ export class XrayGeneratorService {
         const queryPart = query ? `?${query}` : '';
 
         return `hysteria2://${auth}@${host.address}:${host.port}/${queryPart}#${remark}`;
+    }
+
+    // Parses the salamander obfs password out of finalMask.udp[] — the same
+    // shape the mihomo generator reads in buildHysteria2ObfsFields.
+    private parseSalamanderPassword(
+        finalMask: Record<string, unknown> | null,
+    ): string | undefined {
+        return (finalMask as Hysteria2FinalMask | null)?.udp?.find(
+            (m) => m?.type === 'salamander',
+        )?.settings?.password;
     }
 
     // ── Transport Params ─────────────────────────────


### PR DESCRIPTION
### Problem

Hosts with hysteria2 **salamander** obfuscation store the obfs config in `host.streamOverrides.finalMask` (`finalMask.udp[]` where `type === 'salamander'` → `settings.password`).

The **mihomo** generator already handles this correctly — `buildHysteria2ObfsFields()` parses `finalMask` and emits the standard params `obfs: salamander` + `obfs-password`.

The **xray link generator** (`xray.generator.service.ts` → `buildHysteria2Link`) does not: it serializes `finalMask` into a proprietary `fm=<JSON>` query param (understood by Happ), and never emits the standard `obfs` / `obfs-password`.

As a result, any standard (non-Happ) hysteria2 client subscribing via `XRAY_BASE64` silently fails to connect to salamander-obfs nodes — the client dials without obfuscation while the server expects the salamander wrapper, so the handshake never completes.

### Fix

Make the xray link generator emit the standard hysteria2 obfs parameters, parsing the same `finalMask` salamander shape the mihomo generator already reads (mihomo is the precedent for correct behavior here):

- Add `obfs=salamander` + `obfs-password=<password>` to the `hysteria2://` URI query, per the [hysteria2 URI scheme](https://v2.hysteria.network/docs/developers/URI-Scheme/).
- The existing `fm` param is **kept unchanged**, so Happ is unaffected — the standard params are added *in addition*, not as a replacement. Result: `hysteria2://auth@host:port/?sni=..&obfs=salamander&obfs-password=..&fm=..`.

When no salamander obfs is configured, output is byte-for-byte unchanged (guarded on the parsed password).

### Compatibility

Additive only — no existing field is modified or removed. Clients that read `fm` (Happ) ignore the extra params; clients that read the standard `obfs` now get a value consistent with `fm`. Verified against the hysteria2 URI scheme; these params are parsed by sing-box / hysteria official / NekoBox / Streisand.

### Follow-up (not in this PR)

`xray-json.generator.service.ts` (`TRANSPORT_BUILDERS.hysteria`) similarly emits only `version` + `auth`. It could gain the same obfs object, but the exact xray-json `obfs` key layout isn't defined by a schema/test in the repo — happy to send a follow-up once the target shape is confirmed.