### PR TITLE
fix(auth): add frontend domain config for PocketID

### DIFF
--- a/libs/contract/models/remnawave-settings/oauth2-settings.schema.ts
+++ b/libs/contract/models/remnawave-settings/oauth2-settings.schema.ts
@@ -27,6 +27,28 @@ export const Oauth2SettingsSchema = z.object({
                 },
             ),
         ),
+        frontendDomain: z
+            .nullable(
+                z.string().refine(
+                    (val) => {
+                        if (val.startsWith('127.0.0.1') || val.startsWith('localhost')) {
+                            return true;
+                        }
+
+                        const fqdnRegex =
+                            /(?=^.{4,253}$)(^((?!-)[a-zA-Z0-9-]{0,62}[a-zA-Z0-9]\.)+[a-zA-Z]{2,63}$)/;
+                        if (fqdnRegex.test(val)) {
+                            return true;
+                        }
+
+                        return false;
+                    },
+                    {
+                        message: 'Must be a valid fully qualified domain name (FQDN), e.g. "docs.rw"',
+                    },
+                ),
+            )
+            .optional(),
         allowedEmails: z.array(z.string()),
     }),
     yandex: z.object({

--- a/prisma/seed/seeders/3_seed-remnawave-settings.ts
+++ b/prisma/seed/seeders/3_seed-remnawave-settings.ts
@@ -31,6 +31,7 @@ export async function seedRemnawaveSettings(prisma: PrismaClient) {
             clientId: null,
             clientSecret: null,
             plainDomain: null,
+            frontendDomain: null,
             allowedEmails: [],
         },
         yandex: {

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -1091,11 +1091,15 @@ export class AuthService {
         isPocketId: boolean = false,
     ): Promise<arctic.OAuth2Client> {
         if (isPocketId) {
-            const { clientId, clientSecret } = settings.oauth2Settings.pocketid;
+            const { clientId, clientSecret, frontendDomain } = settings.oauth2Settings.pocketid;
             if (!clientId || !clientSecret) {
                 throw new Error('PocketID OAuth2 clientId or clientSecret not configured.');
             }
-            return new arctic.OAuth2Client(clientId, clientSecret, null);
+            if (!frontendDomain) {
+                throw new Error('PocketID OAuth2 frontendDomain not configured.');
+            }
+            const redirectUrl = `https://${frontendDomain}/${AUTH_ROUTES.OAUTH2.CALLBACK}/${OAUTH2_PROVIDERS.POCKETID}`;
+            return new arctic.OAuth2Client(clientId, clientSecret, redirectUrl);
         } else {
             const { clientId, clientSecret, frontendDomain } = settings.oauth2Settings.generic;
             if (!clientId || !clientSecret || !frontendDomain) {

--- a/src/modules/remnawave-settings/remnawave-settings.service.ts
+++ b/src/modules/remnawave-settings/remnawave-settings.service.ts
@@ -132,11 +132,12 @@ export class RemnawaveSettingsService {
             // Test 4: Check up required fields for PocketID authentication
             if (
                 settings.oauth2Settings.pocketid.enabled &&
-                !settings.oauth2Settings.pocketid.plainDomain
+                (!settings.oauth2Settings.pocketid.plainDomain ||
+                    !settings.oauth2Settings.pocketid.frontendDomain)
             ) {
                 return {
                     valid: false,
-                    error: '[PocketID] Plain domain must be set in order to use PocketID authentication.',
+                    error: '[PocketID] Plain domain and frontend domain must be set in order to use PocketID authentication.',
                 };
             }
 


### PR DESCRIPTION
Problem

PocketID authorization fails with:

```
The 'redirect_uri' parameter is required when using OpenID Connect 1.0.
```

In `src/modules/auth/auth.service.ts`, the `getGenericOAuth2Client` method created the `arctic.OAuth2Client` for PocketID with `null` as the third argument (`redirect_uri`). PocketID implements OpenID Connect 1.0, which mandates a `redirect_uri` in the authorization request, so redirecting to `/authorize` failed.

All other providers (Keycloak, Generic, Telegram) build `redirect_uri` from a `frontendDomain` field using the pattern `https://${frontendDomain}/${AUTH_ROUTES.OAUTH2.CALLBACK}/${OAUTH2_PROVIDERS.X}`, but PocketID's settings only had `plainDomain` (the PocketID server's own domain, used for `/authorize` and `/api/oidc/token`) — there was no field for the frontend domain the callback should return to.

### Changes

| File | Change |
| --- | --- |
| `libs/contract/models/remnawave-settings/oauth2-settings.schema.ts` | Added `frontendDomain` field to `pocketid` (mirroring keycloak/generic, with the same FQDN validator and `localhost`/`127.0.0.1` support). Marked `.optional()` on top of `.nullable()` to keep parsing existing DB records intact. |
| `prisma/seed/seeders/3_seed-remnawave-settings.ts` | Added `frontendDomain: null` to the default `pocketid` object for new installations. |
| `src/modules/auth/auth.service.ts` | `getGenericOAuth2Client` for PocketID now reads `frontendDomain`, validates its presence, and builds a correct `redirectUrl`: `https://${frontendDomain}/${AUTH_ROUTES.OAUTH2.CALLBACK}/${OAUTH2_PROVIDERS.POCKETID}`. Arctic uses the client's redirect URI for both `createAuthorizationURL` and `validateAuthorizationCode`. |
| `src/modules/remnawave-settings/remnawave-settings.service.ts` | Test 4 validation now requires both `plainDomain` **and** `frontendDomain` for PocketID, returning `[PocketID] Plain domain and frontend domain must be set...` otherwise. |

### Migration / Required action

After deploying, open PocketID settings and set the new **Frontend Domain** field — the Remnawave frontend domain PocketID should redirect to after authorization (same concept as for Keycloak/Generic). The value must match the redirect URI registered in the PocketID client:

```
https://<frontend_domain>/api/auth/oauth2/callback/pocketid
```

### Backward compatibility

`frontendDomain` is intentionally `.optional()` in the Zod schema. Existing installations store `oauth2Settings` as a JSON column validated via `Oauth2SettingsSchema.safeParse`, and their `pocketid` objects do not contain this field yet. Without `.optional()`, parsing existing records would fail on startup and break settings reads. The runtime guards in `getGenericOAuth2Client` and the settings validator still enforce `frontendDomain` whenever PocketID is enabled.