### PR TITLE
fix(subscription): keep hysteria2 salamander obfs in XRAY_JSON output

### DIFF
--- a/src/modules/subscription-template/generators/xray-json.generator.service.ts
+++ b/src/modules/subscription-template/generators/xray-json.generator.service.ts
@@ -15,6 +15,13 @@ import {
     XrayJsonConfig,
 } from './interfaces/xray-json-config.interface';
 
+interface Hysteria2FinalMask {
+    udp?: Array<{
+        type?: string;
+        settings?: { password?: string };
+    }>;
+}
+
 type VlessConfig = Extract<ResolvedProxyConfig, { protocol: 'vless' }>;
 type TrojanConfig = Extract<ResolvedProxyConfig, { protocol: 'trojan' }>;
 type ShadowsocksConfig = Extract<ResolvedProxyConfig, { protocol: 'shadowsocks' }>;
@@ -121,10 +128,17 @@ const TRANSPORT_BUILDERS: TransportBuilderMap = {
         tti: host.transportOptions.clientTti,
         congestion: host.transportOptions.congestion,
     }),
-    hysteria: (host) => ({
-        version: 2,
-        auth: host.transportOptions.auth,
-    }),
+    hysteria: (host) => {
+        const finalMask = host.streamOverrides.finalMask as Hysteria2FinalMask | null;
+        const obfsPassword = finalMask?.udp?.find((mask) => mask?.type === 'salamander')?.settings
+            ?.password;
+
+        return {
+            version: 2,
+            auth: host.transportOptions.auth,
+            ...(obfsPassword && { obfs: { type: 'salamander', password: obfsPassword } }),
+        };
+    },
 };
 
 function buildTcpSettings(host: ResolvedProxyConfig): Record<string, unknown> {


### PR DESCRIPTION
Closes #201

`TRANSPORT_BUILDERS.hysteria` emitted `version` and `auth` only, so a host with salamander obfuscation configured produced an XRAY_JSON config without obfs and the client could not use that inbound.

The password is now resolved from the same place the share-link generator already uses — `streamOverrides.finalMask.udp[type=salamander].settings.password` — and `obfs` is added only when it is present, so configs without obfuscation are unchanged.

Checked with `tsc --noEmit` and `oxlint` on 3.2.1.
