### PR TITLE
feat(redis): support ACL user and configurable key prefix

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -20,7 +20,7 @@ REDIS_SOCKET=/var/run/valkey/valkey.sock
 # ACL credentials, when the instance requires them
 #REDIS_USER=
 #REDIS_PASSWORD=
-# Prepended to every key and queue name, to share one instance between deployments
+# Prepended to every key, queue and channel name, to share one instance between deployments
 #REDIS_KEY_PREFIX=
 
 ### Secrets ###

--- a/.env.sample
+++ b/.env.sample
@@ -17,6 +17,11 @@ REDIS_SOCKET=/var/run/valkey/valkey.sock
 # Alternative to REDIS_SOCKET
 #REDIS_HOST=
 #REDIS_PORT=
+# ACL credentials, when the instance requires them
+#REDIS_USER=
+#REDIS_PASSWORD=
+# Prepended to every key and queue name, to share one instance between deployments
+#REDIS_KEY_PREFIX=
 
 ### Secrets ###
 APP_SECRET=change_me

--- a/src/bin/cli/cli.ts
+++ b/src/bin/cli/cli.ts
@@ -44,9 +44,10 @@ const redisOptions = getRedisConnectionOptions(
 
 const redis = new Redis({
     ...redisOptions,
+    username: process.env.REDIS_USER,
     password: process.env.REDIS_PASSWORD,
     db: parseInt(process.env.REDIS_DB ?? '1'),
-    keyPrefix: 'rmnwv:',
+    keyPrefix: `${process.env.REDIS_KEY_PREFIX ?? ''}rmnwv:`,
 });
 
 const enum CLI_ACTIONS {

--- a/src/common/config/app-config/config.schema.ts
+++ b/src/common/config/app-config/config.schema.ts
@@ -73,7 +73,9 @@ export const configSchema = z
                 'Port must be between 1 and 65535',
             ),
         REDIS_SOCKET: z.string().optional(),
+        REDIS_USER: z.optional(z.string()),
         REDIS_PASSWORD: z.optional(z.string()),
+        REDIS_KEY_PREFIX: z.string().default(''),
         REDIS_DB: z
             .string()
             .transform((db) => parseInt(db, 10))

--- a/src/common/raw-cache/memory-cache.service.ts
+++ b/src/common/raw-cache/memory-cache.service.ts
@@ -4,6 +4,9 @@ import { LRUCache } from 'lru-cache';
 
 import { Injectable, Logger, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
 
+import { TypedConfigService } from '@common/config/app-config';
+import { getRedisChannelName } from '@common/utils';
+
 @Injectable()
 export class MemoryCacheService implements OnModuleInit, OnModuleDestroy {
     private readonly logger = new Logger(MemoryCacheService.name);
@@ -14,10 +17,17 @@ export class MemoryCacheService implements OnModuleInit, OnModuleDestroy {
         ttl: 30 * 60 * 1000,
     });
 
+    private readonly channel: string;
+
     private subscriber: Redis;
     private everConnected = false;
 
-    constructor(@InjectRedis() private readonly redis: Redis) {}
+    constructor(
+        @InjectRedis() private readonly redis: Redis,
+        configService: TypedConfigService,
+    ) {
+        this.channel = getRedisChannelName(configService, MemoryCacheService.CHANNEL);
+    }
 
     async onModuleInit() {
         this.subscriber = this.redis.duplicate();
@@ -33,7 +43,7 @@ export class MemoryCacheService implements OnModuleInit, OnModuleDestroy {
             else this.cache.delete(key);
         });
 
-        await this.subscriber.subscribe(MemoryCacheService.CHANNEL);
+        await this.subscriber.subscribe(this.channel);
     }
 
     get<T>(key: string): T | undefined {
@@ -46,12 +56,12 @@ export class MemoryCacheService implements OnModuleInit, OnModuleDestroy {
 
     async invalidate(key: string): Promise<void> {
         this.cache.delete(key);
-        await this.redis.publish(MemoryCacheService.CHANNEL, key);
+        await this.redis.publish(this.channel, key);
     }
 
     async invalidateMany(keys: string[]): Promise<void> {
         for (const key of keys) this.cache.delete(key);
-        await Promise.all(keys.map((key) => this.redis.publish(MemoryCacheService.CHANNEL, key)));
+        await Promise.all(keys.map((key) => this.redis.publish(this.channel, key)));
     }
 
     async onModuleDestroy() {

--- a/src/common/raw-cache/raw-cache.module.ts
+++ b/src/common/raw-cache/raw-cache.module.ts
@@ -23,8 +23,9 @@ import { RawCacheService } from './raw-cache.service';
                             'ioredis',
                         ),
                         db: configService.getOrThrow<number>('REDIS_DB'),
+                        username: configService.get<string | undefined>('REDIS_USER'),
                         password: configService.get<string | undefined>('REDIS_PASSWORD'),
-                        keyPrefix: 'ioraw:',
+                        keyPrefix: `${configService.get<string>('REDIS_KEY_PREFIX') ?? ''}ioraw:`,
                     },
                 } satisfies RedisModuleOptions;
             },

--- a/src/common/utils/get-redis-channel-name.ts
+++ b/src/common/utils/get-redis-channel-name.ts
@@ -1,0 +1,5 @@
+import { TypedConfigService } from '@common/config/app-config';
+
+export function getRedisChannelName(configService: TypedConfigService, channel: string): string {
+    return `${configService.get('REDIS_KEY_PREFIX') ?? ''}${channel}`;
+}

--- a/src/common/utils/index.ts
+++ b/src/common/utils/index.ts
@@ -1,6 +1,7 @@
 export * from './certs';
 export * from './convert-type';
 export * from './get-date-range-array.util';
+export * from './get-redis-channel-name';
 export * from './get-redis-connection-options';
 export * from './mask-string';
 export * from './md5';

--- a/src/queue/_nodes/processors/record-node-usage.processor.ts
+++ b/src/queue/_nodes/processors/record-node-usage.processor.ts
@@ -7,7 +7,9 @@ import { CommandBus } from '@nestjs/cqrs';
 import { GetCombinedStatsCommand } from '@remnawave/node-contract';
 
 import { AxiosService } from '@common/axios';
+import { TypedConfigService } from '@common/config/app-config';
 import { RawCacheService } from '@common/raw-cache';
+import { getRedisChannelName } from '@common/utils';
 import { multiplyConsumption } from '@common/utils/nano';
 
 import { NodesUsageHistoryEntity } from '@modules/nodes-usage-history';
@@ -30,12 +32,17 @@ import { IRecordNodeUsagePayload } from '../interfaces';
 export class RecordNodeUsageQueueProcessor extends WorkerHost {
     private readonly logger = new Logger(RecordNodeUsageQueueProcessor.name);
 
+    private readonly nodeMetricsChannel: string;
+
     constructor(
         private readonly commandBus: CommandBus,
         private readonly axios: AxiosService,
         private readonly rawCacheService: RawCacheService,
+        configService: TypedConfigService,
     ) {
         super();
+
+        this.nodeMetricsChannel = getRedisChannelName(configService, NODE_METRICS_MESSAGE_CHANNEL);
     }
 
     async process(job: Job<IRecordNodeUsagePayload>) {
@@ -147,7 +154,7 @@ export class RecordNodeUsageQueueProcessor extends WorkerHost {
         nodeOutboundsMetrics: Map<string, { downlink: string; uplink: string }>;
         nodeInboundsMetrics: Map<string, { downlink: string; uplink: string }>;
     }): void {
-        this.rawCacheService.publishSafe(NODE_METRICS_MESSAGE_CHANNEL, {
+        this.rawCacheService.publishSafe(this.nodeMetricsChannel, {
             nodeUuid: dto.nodeUuid,
             inbounds: Array.from(dto.nodeInboundsMetrics.entries()).map(([tag, metrics]) => ({
                 tag,

--- a/src/queue/queue.module.ts
+++ b/src/queue/queue.module.ts
@@ -73,6 +73,7 @@ const bullBoard = [
             imports: [ConfigModule],
             useFactory: (configService: TypedConfigService) => {
                 return {
+                    prefix: `${configService.get('REDIS_KEY_PREFIX') ?? ''}bull`,
                     connection: {
                         ...getRedisConnectionOptions(
                             configService.get('REDIS_SOCKET'),
@@ -81,6 +82,7 @@ const bullBoard = [
                             'ioredis',
                         ),
                         db: configService.getOrThrow('REDIS_DB'),
+                        username: configService.get('REDIS_USER'),
                         password: configService.get('REDIS_PASSWORD'),
                     },
                     defaultJobOptions: {

--- a/src/scheduler/events/start-all-nodes-by-profile.events.ts
+++ b/src/scheduler/events/start-all-nodes-by-profile.events.ts
@@ -2,6 +2,7 @@ import { QueueEvents } from 'bullmq';
 
 import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
 
+import { TypedConfigService } from '@common/config/app-config';
 import { sleep } from '@common/utils/sleep';
 
 import { NodesQueuesService } from '@queue/_nodes';
@@ -14,13 +15,17 @@ export class StartAllNodesByProfileQueueEvents implements OnModuleInit {
 
     private queueEvents: QueueEvents;
 
-    constructor(private readonly nodesQueuesService: NodesQueuesService) {}
+    constructor(
+        private readonly nodesQueuesService: NodesQueuesService,
+        private readonly configService: TypedConfigService,
+    ) {}
 
     async onModuleInit() {
         this.logger.log('Initializing deduplication event listener.');
 
         this.queueEvents = new QueueEvents(QUEUES_NAMES.NODES.START_ALL_BY_PROFILE, {
             connection: this.nodesQueuesService.queues.startAllNodesByProfile.opts.connection,
+            prefix: `${this.configService.get('REDIS_KEY_PREFIX') ?? ''}bull`,
         });
 
         this.queueEvents.on('deduplicated', async (event) => {

--- a/src/scheduler/tasks/export-metrics/node-metrics.subscriber.ts
+++ b/src/scheduler/tasks/export-metrics/node-metrics.subscriber.ts
@@ -5,6 +5,8 @@ import { Counter } from 'prom-client';
 
 import { Injectable, Logger, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
 
+import { TypedConfigService } from '@common/config/app-config';
+import { getRedisChannelName } from '@common/utils';
 import { METRIC_NAMES } from '@libs/contracts/constants';
 
 import { INodeMetrics, NODE_METRICS_MESSAGE_CHANNEL } from './node-metrics.message.interface';
@@ -13,10 +15,13 @@ import { INodeMetrics, NODE_METRICS_MESSAGE_CHANNEL } from './node-metrics.messa
 export class NodeMetricsSubscriber implements OnModuleInit, OnModuleDestroy {
     private readonly logger = new Logger(NodeMetricsSubscriber.name);
 
+    private readonly channel: string;
+
     private subscriber: Redis;
 
     constructor(
         @InjectRedis() private readonly redis: Redis,
+        configService: TypedConfigService,
         @InjectMetric(METRIC_NAMES.NODE_INBOUND_UPLOAD_BYTES)
         public nodeInboundUploadBytes: Counter<string>,
         @InjectMetric(METRIC_NAMES.NODE_INBOUND_DOWNLOAD_BYTES)
@@ -25,7 +30,9 @@ export class NodeMetricsSubscriber implements OnModuleInit, OnModuleDestroy {
         public nodeOutboundUploadBytes: Counter<string>,
         @InjectMetric(METRIC_NAMES.NODE_OUTBOUND_DOWNLOAD_BYTES)
         public nodeOutboundDownloadBytes: Counter<string>,
-    ) {}
+    ) {
+        this.channel = getRedisChannelName(configService, NODE_METRICS_MESSAGE_CHANNEL);
+    }
 
     async onModuleInit() {
         this.subscriber = this.redis.duplicate();
@@ -38,10 +45,8 @@ export class NodeMetricsSubscriber implements OnModuleInit, OnModuleDestroy {
             void this.handleNodeMetricsMessage(message);
         });
 
-        const count = await this.subscriber.subscribe(NODE_METRICS_MESSAGE_CHANNEL);
-        this.logger.log(
-            `Subscribed to ${NODE_METRICS_MESSAGE_CHANNEL} (active subscriptions: ${count})`,
-        );
+        const count = await this.subscriber.subscribe(this.channel);
+        this.logger.log(`Subscribed to ${this.channel} (active subscriptions: ${count})`);
     }
 
     private handleNodeMetricsMessage(value: string) {


### PR DESCRIPTION
Closes #203

Adds two optional settings, both empty by default, so existing deployments keep their current behaviour byte for byte.

`REDIS_USER` is passed to every connection — queue, raw cache and the CLI — next to the password already supported there. Without it only the `default` user can be used, which rules out an instance where ACL is enabled and the deployment is given its own user.

`REDIS_KEY_PREFIX` is prepended to the existing prefixes (`rmnwv:`, `ioraw:`) and to the BullMQ `prefix`, including the `QueueEvents` instance created outside the module — it has to carry the same prefix or deduplication events stop arriving. With it two installations can share one instance without colliding on keys and queues.

`.env.sample` documents both.

Checked with `tsc --noEmit` and `oxlint` on 3.2.1.
