### PR TITLE
feat: support *_FILE env variables for secrets

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,3 +1,10 @@
+### DOCKER SECRETS ###
+# Any variable the panel validates on startup can be provided in a file instead of a value:
+# point <VARIABLE>_FILE to a file that holds the value, e.g.
+#   APP_SECRET_FILE=/run/secrets/app_secret
+# Handy with Docker Compose "secrets:", which mounts them to /run/secrets/<name>.
+# Setting both <VARIABLE> and <VARIABLE>_FILE aborts the startup.
+
 ### APP ###
 APP_PORT=3000
 METRICS_PORT=3001

--- a/prisma.config.ts
+++ b/prisma.config.ts
@@ -1,7 +1,24 @@
 import 'dotenv/config';
 import type { PrismaConfig } from 'prisma';
 
+import { readFileSync } from 'node:fs';
 import path from 'node:path';
+
+// Docker secrets: DATABASE_URL_FILE/DIRECT_URL_FILE point to a file holding the value.
+// Inlined on purpose, only this file (not src/) is copied into the runtime image.
+for (const key of ['DATABASE_URL', 'DIRECT_URL']) {
+    const filePath = process.env[`${key}_FILE`];
+
+    if (!filePath) {
+        continue;
+    }
+
+    if (process.env[key]) {
+        throw new Error(`${key} and ${key}_FILE are both set. Remove one of them.`);
+    }
+
+    process.env[key] = readFileSync(filePath, 'utf8').replace(/(\r?\n)+$/, '');
+}
 
 if (!process.env.DIRECT_URL) {
     // eslint-disable-next-line no-console

--- a/prisma.config.ts
+++ b/prisma.config.ts
@@ -17,7 +17,13 @@ for (const key of ['DATABASE_URL', 'DIRECT_URL']) {
         throw new Error(`${key} and ${key}_FILE are both set. Remove one of them.`);
     }
 
-    process.env[key] = readFileSync(filePath, 'utf8').replace(/(\r?\n)+$/, '');
+    const value = readFileSync(filePath, 'utf8').replace(/(\r?\n)+$/, '');
+
+    if (!value) {
+        throw new Error(`${key}_FILE points to "${filePath}", which is empty.`);
+    }
+
+    process.env[key] = value;
 }
 
 if (!process.env.DIRECT_URL) {

--- a/prisma/seed/config.seed.ts
+++ b/prisma/seed/config.seed.ts
@@ -7,7 +7,9 @@ import timezone from 'dayjs/plugin/timezone';
 import utc from 'dayjs/plugin/utc';
 import { Redis } from 'ioredis';
 
+import { configSchema } from '@common/config/app-config/config.schema';
 import { getRedisConnectionOptions } from '@common/utils';
+import { loadSecretsFromFiles } from '@common/utils/load-secrets-from-files';
 
 import {
     checkupExternalSquads,
@@ -25,6 +27,8 @@ import {
     migrateScopes,
     migrateSharedLists,
 } from './seeders';
+
+loadSecretsFromFiles(process.env, Object.keys(configSchema.shape));
 
 dayjs.extend(utc);
 dayjs.extend(relativeTime);

--- a/src/bin/cli/cli.ts
+++ b/src/bin/cli/cli.ts
@@ -15,12 +15,16 @@ import timezone from 'dayjs/plugin/timezone';
 import utc from 'dayjs/plugin/utc';
 import Redis from 'ioredis';
 
+import { configSchema } from '@common/config/app-config/config.schema';
 import { getRedisConnectionOptions } from '@common/utils';
 import { generateNodeCert } from '@common/utils/certs';
 import { encodeCertPayload } from '@common/utils/certs/encode-node-payload';
+import { loadSecretsFromFiles } from '@common/utils/load-secrets-from-files';
 import { CACHE_KEYS } from '@libs/contracts/constants';
 
 import { TResponseRuleEncryption } from '@modules/subscription-response-rules/types/response-rules.types';
+
+loadSecretsFromFiles(process.env, Object.keys(configSchema.shape));
 
 dayjs.extend(utc);
 dayjs.extend(relativeTime);

--- a/src/common/config/common-config/common-config.module.ts
+++ b/src/common/config/common-config/common-config.module.ts
@@ -1,6 +1,7 @@
 import { Global, Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 
+import { loadSecretsFromFiles } from '@common/utils/load-secrets-from-files';
 import { validateEnvConfig } from '@common/utils/validate-env-config';
 
 import { configSchema, Env } from '../app-config';
@@ -15,7 +16,11 @@ import { NotificationsConfigService } from './notifications-config.service';
             isGlobal: true,
             cache: true,
             envFilePath: '.env',
-            validate: (config) => validateEnvConfig<Env>(configSchema, config),
+            validate: (config) =>
+                validateEnvConfig<Env>(
+                    configSchema,
+                    loadSecretsFromFiles(config, Object.keys(configSchema.shape)),
+                ),
             load: [notificationsConfig],
         }),
     ],

--- a/src/common/utils/load-secrets-from-files.ts
+++ b/src/common/utils/load-secrets-from-files.ts
@@ -1,0 +1,60 @@
+import { readFileSync } from 'node:fs';
+
+/**
+ * Docker/Podman secrets support.
+ *
+ * For every known variable `X` the value can be provided in a file by setting `X_FILE`
+ * (e.g. `APP_SECRET_FILE=/run/secrets/app_secret`), the same convention the official
+ * postgres/mysql images use. Resolved values are written both to the returned config
+ * and to `process.env`, so consumers that read `process.env` directly (Prisma) see them too.
+ *
+ * Secret values are never included in error messages or logs.
+ */
+export function loadSecretsFromFiles<T extends Record<string, unknown>>(
+    config: T,
+    keys: readonly string[],
+): T {
+    const resolvedConfig: Record<string, unknown> = { ...config };
+
+    for (const key of keys) {
+        const fileKey = `${key}_FILE`;
+        const filePath = nonEmptyString(resolvedConfig[fileKey]);
+
+        if (!filePath) {
+            continue;
+        }
+
+        if (nonEmptyString(resolvedConfig[key])) {
+            throw new Error(
+                `❌ ${key} and ${fileKey} are both set. Remove one of them and restart the application.`,
+            );
+        }
+
+        let value: string;
+
+        try {
+            value = readFileSync(filePath, 'utf8');
+        } catch (error) {
+            const code = (error as NodeJS.ErrnoException).code ?? 'unknown error';
+
+            throw new Error(
+                `❌ ${fileKey} points to "${filePath}", which can not be read: ${code}`,
+            );
+        }
+
+        value = value.replace(/(\r?\n)+$/, '');
+
+        if (!value) {
+            throw new Error(`❌ ${fileKey} points to "${filePath}", which is empty.`);
+        }
+
+        resolvedConfig[key] = value;
+        process.env[key] = value;
+    }
+
+    return resolvedConfig as T;
+}
+
+function nonEmptyString(value: unknown): string | undefined {
+    return typeof value === 'string' && value !== '' ? value : undefined;
+}


### PR DESCRIPTION
Opening this as a PR for concreteness — happy to move the discussion to an issue first, as CONTRIBUTING asks, if you prefer.

## Problem

Every secret the panel needs — `APP_SECRET`, `DATABASE_URL` (which carries the database password), `TELEGRAM_BOT_TOKEN`, `METRICS_PASS`, `WEBHOOK_SECRET_HEADER` — can only be passed as a plain environment variable, so on a Docker/Podman host they sit in a plaintext `.env` next to the compose file and show up in `docker inspect` and in every process environment.

Docker Compose already has `secrets:` for this: the value is mounted as a file in `/run/secrets/<name>`. The official `postgres` / `mysql` images consume it through the `<VARIABLE>_FILE` convention. This PR teaches the panel the same convention.

## What it does

For any variable `X` known to the config schema, the value can be supplied in a file by setting `X_FILE`:

```
APP_SECRET_FILE=/run/secrets/app_secret
```

- the file is read before env validation, trailing newlines stripped;
- `X` and `X_FILE` both set → startup aborts with a clear message instead of silently picking one;
- `X_FILE` pointing at an unreadable or empty file → startup aborts; the message carries the path and the errno, never the contents;
- secret values are never logged or put into an error message.

## Backward compatibility

Nothing happens unless a `*_FILE` variable is set — the helper walks the known keys, finds no `*_FILE`, and returns the config untouched. Existing `.env` deployments behave exactly as before.

## Why resolution sits in three places

Resolved values go into `process.env` as well as into the validated config, because several processes read `process.env` directly:

| surface | why it needs it |
| --- | --- |
| `common-config.module.ts` (`validate`) | api / scheduler / processor. Runs before Nest boots, so the in-process `PrismaClient` sees the resolved `DATABASE_URL` |
| `prisma.config.ts` | `prisma migrate deploy` and `prisma db seed` run from `docker-entrypoint.sh` as a separate process before the app starts. Inlined (~10 lines) on purpose: only this file, not `src/`, is copied into the runtime image |
| `cli.ts`, `config.seed.ts` | both build their own `PrismaClient` / `Redis` from `process.env` at import time |

Doing it in `docker-entrypoint.sh` alone would not cover the app: `docker-compose-advanced-prod.yml` sets `entrypoint: []` for the rest-api and processor services, so those containers never run that script.

## Compose example

```yaml
services:
  remnawave:
    image: remnawave/backend:3
    env_file: .env
    environment:
      APP_SECRET_FILE: /run/secrets/app_secret
      DATABASE_URL_FILE: /run/secrets/database_url
      TELEGRAM_BOT_TOKEN_FILE: /run/secrets/telegram_bot_token
    secrets:
      - app_secret
      - database_url
      - telegram_bot_token

secrets:
  app_secret:
    file: ./secrets/app_secret
  database_url:
    file: ./secrets/database_url
  telegram_bot_token:
    file: ./secrets/telegram_bot_token
```

The variables handed over to secrets must then be removed from `.env`. `postgres` supports `POSTGRES_PASSWORD_FILE` natively, so the db service can share the same secret files.

## How it was verified

- `npm run build`, `npm run build:seed` and `oxlint` are clean; `oxfmt --check` reports the same 18 pre-existing files as `main` does, none of them touched here.
- Helper behaviour, compiled standalone and asserted: plain variable untouched; `*_FILE` read with trailing newline stripped; both set → throws without leaking either value; missing file → message has path + `ENOENT` and no contents; empty file → throws; empty `*_FILE` treated as unset.
- Built bundles, actual startup:
  - `node dist/app.js` with plain `APP_SECRET` / `DATABASE_URL` and with `APP_SECRET_FILE` / `DATABASE_URL_FILE` — both pass env validation and reach `NestFactory` (they stop later at Redis/DB, which were not running locally);
  - both set → `❌ APP_SECRET and APP_SECRET_FILE are both set...`; missing file → `❌ APP_SECRET_FILE points to "...", which can not be read: ENOENT`;
  - `prisma migrate deploy` with only `DATABASE_URL_FILE` set connects to the host from the file (`P1001` at that address); the same env without this change fails with `P1012: Environment variable not found: DATABASE_URL`;
  - `node dist/cli.js` and `node dist/seed.js` with only `DATABASE_URL_FILE` set pick the URL up from the file.
- Not verified: a full boot against a live Postgres/Valkey — no Docker on the machine used.

Happy to trim the scope (drop the CLI/seed call sites, reword the `.env.sample` note) if you would rather keep the surface smaller.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
