### PR TITLE
fix: bound alphanumeric runs in generated shortUuid

### DIFF
--- a/src/modules/users/users.service.ts
+++ b/src/modules/users/users.service.ts
@@ -837,20 +837,26 @@ export class UsersService {
     private createNanoId(): string {
         const alphabet = '0123456789ABCDEFGHJKLMNPQRSTUVWXYZ_abcdefghjkmnopqrstuvwxyz-';
         const nanoid = customAlphabet(alphabet, this.shortUuidLength);
-        const shortUuid = nanoid();
 
-        // Some CDNs reject a path segment built of 16+ consecutive alphanumerics as a
-        // hash-like URL and answer 403 without contacting the origin. SHORT_UUID_LENGTH
-        // has a floor of 16, so a shortUuid that happens to contain no separator lands
-        // exactly on that heuristic. Guarantee one so subscription links stay reachable.
-        if (/[-_]/.test(shortUuid)) {
-            return shortUuid;
+        // Some CDNs reject a path segment containing 16+ consecutive alphanumerics as a
+        // hash-like URL and answer 403 without ever contacting the origin. SHORT_UUID_LENGTH
+        // allows 16..64, so break every such run with a separator the alphabet already
+        // contains, keeping subscription links reachable through those CDNs.
+        const maxAlphanumericRun = 15;
+        const longRun = /[0-9A-Za-z]{16,}/;
+
+        let shortUuid = nanoid();
+        let match = longRun.exec(shortUuid);
+
+        while (match !== null) {
+            const position = match.index + randomInt(maxAlphanumericRun + 1);
+            const separator = randomInt(2) === 0 ? '-' : '_';
+
+            shortUuid = shortUuid.slice(0, position) + separator + shortUuid.slice(position + 1);
+            match = longRun.exec(shortUuid);
         }
 
-        const position = randomInt(shortUuid.length);
-        const separator = randomInt(2) === 0 ? '-' : '_';
-
-        return shortUuid.slice(0, position) + separator + shortUuid.slice(position + 1);
+        return shortUuid;
     }
 
     private createPassword(length: number = 32): string {

--- a/src/modules/users/users.service.ts
+++ b/src/modules/users/users.service.ts
@@ -1,7 +1,7 @@
 import { Prisma } from '@prisma/client';
 import dayjs from 'dayjs';
 import { customAlphabet } from 'nanoid';
-import { randomUUID } from 'node:crypto';
+import { randomInt, randomUUID } from 'node:crypto';
 
 import { Injectable, Logger } from '@nestjs/common';
 import { EventBus, QueryBus } from '@nestjs/cqrs';
@@ -837,8 +837,20 @@ export class UsersService {
     private createNanoId(): string {
         const alphabet = '0123456789ABCDEFGHJKLMNPQRSTUVWXYZ_abcdefghjkmnopqrstuvwxyz-';
         const nanoid = customAlphabet(alphabet, this.shortUuidLength);
+        const shortUuid = nanoid();
 
-        return nanoid();
+        // Some CDNs reject a path segment built of 16+ consecutive alphanumerics as a
+        // hash-like URL and answer 403 without contacting the origin. SHORT_UUID_LENGTH
+        // has a floor of 16, so a shortUuid that happens to contain no separator lands
+        // exactly on that heuristic. Guarantee one so subscription links stay reachable.
+        if (/[-_]/.test(shortUuid)) {
+            return shortUuid;
+        }
+
+        const position = randomInt(shortUuid.length);
+        const separator = randomInt(2) === 0 ? '-' : '_';
+
+        return shortUuid.slice(0, position) + separator + shortUuid.slice(position + 1);
     }
 
     private createPassword(length: number = 32): string {


### PR DESCRIPTION
## Problem

Some CDNs reject a path segment built of **16 or more consecutive alphanumerics** as a hash-like URL — a widespread anti-abuse heuristic aimed at hidden file distribution. The edge answers `403` and never contacts the origin, so nothing on the origin side can compensate.

`createNanoId()` draws from a 60-character alphabet that *contains* `-` and `_`, but does not guarantee either appears. `SHORT_UUID_LENGTH` is floored at 16 by the config schema, so a `shortUuid` that happens to be drawn without a separator matches that heuristic exactly:

```
P(no separator) = (58/60)^16 ≈ 0.581
```

## Measured on a live install

- **1118 of 1858** distinct subscription tokens (60.2%) are pure alphanumeric — consistent with the 58.1% predicted above.
- Two tokens from that same install, requested through such a CDN seconds apart:

| token | longest alphanumeric run | result |
|---|---|---|
| `8w_…` (contains `_`) | 13 | `200`, 14763 bytes, byte-identical to the origin response |
| `Abw…` (pure alphanumeric) | 16 | `403`, origin never contacted |

The failure mode is the awkward one: not an outage but arbitrary partial breakage, where roughly six users in ten cannot load their subscription while the rest are fine, with no pattern visible to them or to support.

## Why the existing knobs don't cover it

- `CUSTOM_SUB_PREFIX` does not help — the heuristic evaluates each path segment independently, so a prefix leaves the token segment untouched (verified against a live CDN).
- `SHORT_UUID_LENGTH` cannot go below 16 by schema, and 16 is exactly the trigger.

## The change

Generate as before, then break any run of 16+ consecutive alphanumerics by replacing a character inside it with a separator the alphabet already contains, repeating until no such run remains.

Verified across every supported length (16, 17, 20, 31, 32, 33, 48, 64): the longest alphanumeric run is always ≤ 15, the length never changes, and the loop terminates — at most 12 rewrites at length 64, averaging 0.58 at the default 16.

Deliberately minimal:

- **length, alphabet and URL structure are unchanged** — no client, route or documentation impact;
- **existing shortUuids are untouched**, so nothing currently issued changes;
- entropy is unaffected in practice — ~94.5 bits at 16 characters drawn from 60, and the rewrite spends about 4.9 bits on one position while returning ~5 in position and separator choice.

## Notes

This only helps newly generated values, which is the intended scope — an already-issued subscription URL lives inside each client app and cannot be migrated centrally.

Per `CONTRIBUTING.md` this is discussed in remnawave/backend#211, which also carries the measurements and a complementary suggestion for `subscription-page`. Happy to adjust the approach — an alternative would be to reserve a fixed position for the separator, at the cost of a slightly more predictable shape.



