### PR TITLE
Use simplified VLESS syntax in XRAY_JSON

### DIFF
--- a/src/modules/subscription-template/generators/interfaces/xray-json-config.interface.ts
+++ b/src/modules/subscription-template/generators/interfaces/xray-json-config.interface.ts
@@ -19,18 +19,11 @@ export interface StreamSettings {
 }
 
 export interface OutboundSettings {
-    vnext?: Array<{
-        address: string;
-        port: number;
-        users: Array<{
-            id: string;
-            security?: string;
-            encryption?: string;
-            flow?: string;
-            alterId?: number;
-            email?: string;
-        }>;
-    }>;
+    address?: string;
+    port?: number;
+    id?: string;
+    encryption?: string;
+    flow?: string;
     servers?: Array<{
         address: string;
         port: number;

--- a/src/modules/subscription-template/generators/xray-json.generator.service.ts
+++ b/src/modules/subscription-template/generators/xray-json.generator.service.ts
@@ -47,19 +47,11 @@ type TransportBuilderMap = {
 };
 const PROTOCOL_BUILDERS: ProtocolBuilderMap = {
     vless: (host) => ({
-        vnext: [
-            {
-                address: host.address,
-                port: host.port,
-                users: [
-                    {
-                        id: host.protocolOptions.id,
-                        encryption: host.protocolOptions.encryption || 'none',
-                        flow: host.protocolOptions.flow,
-                    },
-                ],
-            },
-        ],
+        address: host.address,
+        port: host.port,
+        id: host.protocolOptions.id,
+        encryption: host.protocolOptions.encryption || 'none',
+        flow: host.protocolOptions.flow,
     }),
 
     trojan: (host) => ({


### PR DESCRIPTION
In Xray-core v26.9.8, VLESS Encryption configurations using the old `vnext` structure fail the new security validation: Xray does not detect `encryption` inside the user object and treats the connection as unencrypted.

This PR updates the XRAY_JSON generator to use the new simplified VLESS syntax with the `address`, `port`, `id`, `encryption`, and `flow` fields.
